### PR TITLE
seqs: add modulator randomization and better tape stop options.

### DIFF
--- a/SequencedFX/SequencedFX.jsfx
+++ b/SequencedFX/SequencedFX.jsfx
@@ -1,8 +1,8 @@
 desc:Saike SEQS (Sequenced FX) (beta)
 tags: time-based effect
-version: 0.73
+version: 0.75
 author: Joep Vanlier
-changelog: treat situation when buffer runs out as though "reset" was called (with a little fade)
+changelog: fix bug interaction slowdown and tapestop
 license: MIT
 provides:
   seqs_dependencies/*
@@ -92,7 +92,7 @@ import saike_seqs_pitchlib.jsfx-inc
 
 @init
 gfx_ext_retina = 1;
-CURRENT_VERSION = 5;
+CURRENT_VERSION = 6;
 version = CURRENT_VERSION;
 DRAG_STRING = 50;
 DRAG_BLOCK = 1;
@@ -157,6 +157,28 @@ function to_order_mem()
   order_mem[7] = effect8;
   order_mem[8] = effect9;
   order_mem[9] = effect10;
+);
+
+function time_func(t)
+global(current_tapestop_depth, current_tapestop_shape)
+local(func)
+(
+  func = 6 * current_tapestop_shape;
+  (func < 1) ? (
+    t * (1.0 - exp(-5 * pow(t, .5 + 5 * current_tapestop_depth)))
+  ) : (func < 2) ? (
+    (1 + 2 * current_tapestop_depth * exp(-4 * t)) * t * (1.0 - exp(-15 * t))
+  ) : (func < 3) ? (
+    (4 * current_tapestop_depth * exp(-4 * t)) * t * (1.0 - exp(-13 * t))
+  ) : (func < 4) ? (
+    t * (1.0 - exp(-4 * t) * cos(8 * current_tapestop_depth * $pi * t))
+  ) : (func < 5) ? (
+    (4 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
+  ) : (func < 6) ? (
+    (8 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
+  ) : (func < 7) ? (
+    t - t * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t)) * exp(-3 * t)
+  );
 );
 
 // Generated functions with labels for tempo sync delays
@@ -455,6 +477,9 @@ function update_current_levels()
   
   current_tapestop_decay = tapestopSpeedKnob.getCurrentValue();
   
+  current_tapestop_depth = tapestopDepthKnob.getCurrentValue();
+  current_tapestop_shape = tapestopShapeKnob.getCurrentValue();
+  
   current_karplus_pitch = karplusPitchKnob.getCurrentValue();
   current_karplus_feedback = karplusFeedback.getCurrentValue();
   current_karplus_cutoff = karplusCutoffKnob.getCurrentValue();
@@ -540,6 +565,9 @@ function init_controls()
   degradeMix.init_knob(1, 0, 0, 1.0);
   
   tapestopSpeedKnob.init_knob(1, 0, 0, 0.6);
+  
+  tapestopDepthKnob.init_knob(1, 0, 0, 1.0);
+  tapestopShapeKnob.init_knob(1, 0, 0, 1.0);
   
   karplusPitchKnob.init_knob(1, 0, 0, 0.5);
   karplusFeedback.init_knob(1, 0, 0, 0.15);
@@ -1342,6 +1370,14 @@ do_not_store_samples = 1 - has_samples;
 
 playheadWet.serialize_knob();
 playheadDry.serialize_knob();
+tapestopDepthKnob.serialize_knob();
+tapestopShapeKnob.serialize_knob();
+
+((!writing) && (last_read_version < 6)) ? (
+  advanced_tapestop = 0;
+) : (
+  file_var(0, advanced_tapestop);
+);
 
 update_current_levels();
 version = CURRENT_VERSION; // Update to current version
@@ -2145,6 +2181,10 @@ jump_schedule.eval_jump();
     stop_factor = 1;
     t_stop = 0;
     t_stop_length = tapestop_envelope.env_attack_samples;
+    
+//    time_sec = tapestop_envelope.env_attack_samples * 9.89895 / srate;
+    time_samples = tapestop_envelope.env_attack_samples * 9.89895;
+    tapestop_envelope.delta_time = 1.0 / time_samples;
   );
   tapestop_target = abs(tapestop_target);
   
@@ -2163,14 +2203,20 @@ jump_schedule.eval_jump();
   update_current_levels();
 );
 
+target_time_warp = 0;
 tapestop_target ? (
-  move_mode == 0 ? (
-    stop_factor = (1.0 - tapestop_envelope.k_decay) * stop_factor;
-    dyn_speed = 1.0 - (stop_factor * (1.0 - speed));
+  (advanced_tapestop == 0) ? (
+    move_mode == 0 ? (
+      stop_factor = (1.0 - tapestop_envelope.k_decay) * stop_factor;
+      dyn_speed = 1.0 - (stop_factor * (1.0 - speed));
+    ) : (
+      stop_factor = stop_factor + tapestop_envelope.k_decay * ((t_stop > 10 * tapestop_envelope.env_attack_samples) - stop_factor);
+      t_stop += 1.0;
+      dyn_speed = 1.0 - (stop_factor * (1.0 - speed));
+    );
   ) : (
-    stop_factor = stop_factor + tapestop_envelope.k_decay * ((t_stop > 10 * tapestop_envelope.env_attack_samples) - stop_factor);
-    t_stop += 1.0;
-    dyn_speed = 1.0 - (stop_factor * (1.0 - speed));
+    dyn_speed = speed + time_func(t_stop) / t_stop;
+    t_stop += tapestop_envelope.delta_time;
   );
 );
 
@@ -3230,6 +3276,10 @@ instance(start_idx, h, subdiv, snap)
 );
 
 draw_logo(12 * (1+scaling), 10 * (1+scaling), 6 * (1+scaling), 6 * (1+scaling));
+gfx_set(1, 1, 1, .1);
+gfx_x = 150 * (1+scaling);
+gfx_y = 30 * (1+scaling);
+gfx_printf("v0.75");
 
 scope_w = ceil((block_width + block_spacing) * 33);
 scope_h = 35 * (1 + scaling);
@@ -3495,6 +3545,52 @@ global()
   
 dragging = 0;
 set_row_color(selected_row);
+  
+function time_func_draw(x, y, w, h)
+global(dial_position_color_r, dial_position_color_g, dial_position_color_b,
+       gfx_x, gfx_y)
+local(s, ds, cx, cy, ly, ww, hh, v)
+(
+  cx = x;
+  ds = 1.0 / w;
+  s = 0;
+  gfx_set(0, 0, 0, 0.7);
+  gfx_rect(x, y, w, h);
+  
+  gfx_set(dial_position_color_r, dial_position_color_g, dial_position_color_b, 0.5);
+  gfx_line(x, y, x + w, y);
+  gfx_line(x, y + 0.5 * h, x + w, y + 0.5 * h);
+  gfx_line(x, y + 0.25 * h, x + w, y + 0.25 * h);
+  gfx_line(x, y + 0.75 * h, x + w, y + 0.75 * h);
+  gfx_line(x, y + h, x + w, y + h);
+  
+  gfx_set(dial_position_color_r, dial_position_color_g, dial_position_color_b, 1.0);
+
+  ly = y;
+  loop(w,
+    v = time_func(s) / (2*s);
+    cy = y + h * v;
+//    cy = min(y + h, max(y, cy));
+    s += ds;
+    gfx_line(cx, ly, cx + 1, cy);
+    gfx_line(cx, ly - 1, cx + 1, cy - 1);
+    cx += 1;
+    ly = cy;
+  );
+  
+  gfx_set(dial_position_color_r + 0.2, dial_position_color_g + 0.2, dial_position_color_b, 1.0);
+  gfx_setfont(13, "Arial", 9);
+  gfx_measurestr("0x", ww, hh);
+  gfx_x = x + w - ww - 2;
+  gfx_y = y;
+  gfx_printf("1x");
+  gfx_x = x + w - ww - 2;
+  gfx_y = y + 0.5 * h - 0.5 * hh;
+  gfx_printf("0x");
+  gfx_x = x + w - ww - 2;
+  gfx_y = y + h - hh;
+  gfx_printf("-1x");
+);
 
 function drawBuf(idx, x, y, w, h)
 global(samplelocs, row_color_r, row_color_g, row_color_b, gfx_x, gfx_y, SAMPLE_FONT)
@@ -3836,7 +3932,7 @@ local(length_in_samples, len, ptr, hh, xp, ym, step, minacc, maxacc, ww, hh)
 ) : ( selected_details == 10 ) ? (
   // Tape stop
   min_degrade = 3;
-  nextPanel = drawPanel(s_TAPESTOP, cX, cY - 1.5 * knobSize, 11.5*knobSpacing, panelHeight, tapestop_enabled);
+  nextPanel = drawPanel(s_TAPESTOP, cX, cY - 1.5 * knobSize, 23.75*knobSpacing, panelHeight, tapestop_enabled);
   
   cX += knobSize * 1.35;
   tapestopSpeedKnob.knob_set_display(DECAY_SLIDER, tapestop_enabled);
@@ -3849,7 +3945,21 @@ local(length_in_samples, len, ptr, hh, xp, ym, step, minacc, maxacc, ww, hh)
     
   playheadWet.knob_set_display(DB_SLIDER, tapestop_enabled);
   playheadWet.drawAndProcess(cX, cY, knobSize, "Wet", "Wet signal level.\n\nNote that this parameter is shared\nbetween all playhead-based effects.", current_playhead_wet, 1, 1, 1);
+  
   cX += 2.5*knobSize;
+
+  tapeStopToggle.drawToggle(cX - knobSize, cY - knobSize, 0.15*knobSize, 0.15*knobSize, advanced_tapestop, row_color_r, row_color_g, row_color_b, widget_a, row_color_r, row_color_g*2, row_color_b, toggle_a, "Curve controls for tape stop.");
+  advanced_tapestop = tapeStopToggle.processMouseToggle(mouse_x, mouse_y, mouse_cap);
+  
+  tapestopShapeKnob.knob_set_display(NORMALIZED_SLIDER, tapestop_enabled && advanced_tapestop);
+  tapestopShapeKnob.drawAndProcess(cX, cY, knobSize, "Shape", "Tapestop modulation shape.", current_tapestop_shape, 1, 1, 1);
+       
+  cX += 2.5*knobSize;
+  tapestopDepthKnob.knob_set_display(NORMALIZED_SLIDER, tapestop_enabled && advanced_tapestop);
+  tapestopDepthKnob.drawAndProcess(cX, cY, knobSize, "Depth", "Modulation depth.", current_tapestop_depth, 1, 1, 1);
+
+  cX += 1.5*knobSize;  
+  time_func_draw(cX, cY - 0.75 * knobSize, knobSize * 3.25, knobSize * 2);
 ) : ( selected_details == 11 ) ? (
   // Tonal delay
   min_degrade = 3;

--- a/SequencedFX/SequencedFX.jsfx
+++ b/SequencedFX/SequencedFX.jsfx
@@ -1,8 +1,8 @@
 desc:Saike SEQS (Sequenced FX) (beta)
 tags: time-based effect
-version: 0.76
+version: 0.77
 author: Joep Vanlier
-changelog: Allow learning power buttons and various other controls. Allow randomizing modulator A and B.
+changelog: Make advanced tapestop mode the default. Add a few more tapestop shapes. Rename tape stop knob. Add mode to control tapestop shape on the timeline instead.
 license: MIT
 provides:
   seqs_dependencies/*
@@ -102,6 +102,7 @@ DRAG_EFFECT_2 = 4;
 DRAG_SOLO = 5;
 DRAG_MODSIZE = 6;
 loaded_pattern = -1;
+TAPESTOP_MAX = 10;
 
 log10d20_conversion  = 0.11512925464970228420089957273422;
 
@@ -159,25 +160,33 @@ function to_order_mem()
   order_mem[9] = effect10;
 );
 
-function time_func(t)
+function time_func(func, t)
 global(current_tapestop_depth, current_tapestop_shape)
-local(func)
+local(cc)
 (
-  func = 6 * current_tapestop_shape;
   (func < 1) ? (
     t * (1.0 - exp(-5 * pow(t, .5 + 5 * current_tapestop_depth)))
   ) : (func < 2) ? (
     (1 + 2 * current_tapestop_depth * exp(-4 * t)) * t * (1.0 - exp(-15 * t))
   ) : (func < 3) ? (
-    (4 * current_tapestop_depth * exp(-4 * t)) * t * (1.0 - exp(-13 * t))
+    t - t * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t)) * exp(-3 * t)
   ) : (func < 4) ? (
     t * (1.0 - exp(-4 * t) * cos(8 * current_tapestop_depth * $pi * t))
   ) : (func < 5) ? (
-    (4 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
+    (4 * current_tapestop_depth * exp(-4 * t)) * t * (1.0 - exp(-13 * t))
   ) : (func < 6) ? (
-    (8 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
+    (4 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
   ) : (func < 7) ? (
-    t - t * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t)) * exp(-3 * t)
+    (8 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
+  ) : (func < 8) ? (
+    (45 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-1 * t)) * (0.5 + 0.5 * cos(16 * current_tapestop_depth * $pi * t))
+  ) : (func < 9) ? (
+    t * (8*current_tapestop_depth*t - floor(8*current_tapestop_depth*t)) / (0.4 + 3*current_tapestop_depth*t)
+  ) : (func < 10) ? (
+    1.5 * exp(-2 * t) * (t - t * (0.5 + 0.5 * cos($pi * (exp(4 * current_tapestop_depth * t) - 1))))
+  ) : (func < 11) ? (
+    cc = 2 * t - 0.5;
+    2 * t * abs(cc - floor(cc) - 0.5) * exp(-(1.0 - current_tapestop_depth) * t);
   );
 );
 
@@ -590,7 +599,7 @@ function init_controls()
   tapestopSpeedKnob.init_knob(1, 0, 0, 0.6);
   
   tapestopDepthKnob.init_knob(1, 0, 0, 1.0);
-  tapestopShapeKnob.init_knob(1, 0, 0, 1.0);
+  tapestopShapeKnob.init_knob(TAPESTOP_MAX, 0, 0, 1.0);
   
   karplusPitchKnob.init_knob(1, 0, 0, 0.5);
   karplusFeedback.init_knob(1, 0, 0, 0.15);
@@ -1141,6 +1150,7 @@ writing = file_avail(0) < 0;
 loaded = 1;
 file_var(0, version);
 !writing ? last_read_version = version;
+
 (version < 3) ? (
   file_mem(0, pattern_buffer, pattern_size * max_stored_patterns);
 ) : (
@@ -1397,10 +1407,11 @@ tapestopDepthKnob.serialize_knob();
 tapestopShapeKnob.serialize_knob();
 
 ((!writing) && (last_read_version < 6)) ? (
-  advanced_tapestop = 1;
+  legacy_tapestop = 1;
 ) : (
-  file_var(0, advanced_tapestop);
+  file_var(0, legacy_tapestop);
 );
+advanced_tapestop = 1 - legacy_tapestop;
 
 ((!writing) && (last_read_version < 7)) ? (
   randomizing_modulator_a = 0;
@@ -1408,6 +1419,12 @@ tapestopShapeKnob.serialize_knob();
 ) : (
   file_var(0, randomizing_modulator_a);
   file_var(0, randomizing_modulator_b);
+);
+
+((!writing) && (last_read_version < 7)) ? (
+  timeline_tapestop = 0;
+) : (
+  file_var(0, timeline_tapestop);
 );
 
 update_current_levels();
@@ -2212,7 +2229,7 @@ jump_schedule.eval_jump();
   degrade_target = abs(degrade_values[sequencer_index]);
   
   tapestop_target = tapestop_enabled ? tapestop_values[sequencer_index] : 0;
-  tapestop_target == 1 ? (
+  (tapestop_target > 0) ? (
     tapestop_envelope.calc_times_universal(current_tapestop_decay, current_tapestop_decay, 0);
     stop_factor = 1;
     t_stop = 0;
@@ -2251,7 +2268,7 @@ tapestop_target ? (
       dyn_speed = 1.0 - (stop_factor * (1.0 - speed));
     );
   ) : (
-    dyn_speed = speed + time_func(t_stop) / t_stop;
+    dyn_speed = speed + time_func(timeline_tapestop ? tapestop_target : current_tapestop_shape, t_stop) / t_stop;
     t_stop += tapestop_envelope.delta_time;
   );
 );
@@ -3338,7 +3355,7 @@ gfx_y = y_current - block_width;
 gfx_printf(" BETA");
 y_current = process_effect_row(0, 1, reset_values, x_current, y_current, "Reset", 1, 10, "Reset the playhead to the current position.\n\nThis is often useful after a slowdown effect to\nmake sure we catch up to the current position.\n\nNote that the first block cannot be removed.");
 y_current = process_effect_row(1, 2, speed_values, x_current, y_current, "Slowdown", slowdown_scaling == 0 ? 24 : 4, 11, "Slow down playback.");
-y_current = process_effect_row(2, 10, tapestop_values, x_current, y_current, "Tape Stop", 1, 19, "Tape stop effect.");
+y_current = process_effect_row(2, 10, tapestop_values, x_current, y_current, "Tape Stop", timeline_tapestop ? TAPESTOP_MAX : 1, 19, "Tape stop effect.");
 y_current = process_effect_row(3, 4, retrig_values, x_current, y_current, "Retrigger", 6, 13, "Retrigger last block N times.");
 y_current = process_effect_row(4, 5, reverse_values, x_current, y_current, "Reverse", 1, 14, "Reverse playhead playing a reversed\nversion of the last block.");
 
@@ -3574,7 +3591,7 @@ global()
 dragging = 0;
 set_row_color(selected_row);
   
-function time_func_draw(x, y, w, h)
+function time_func_draw(func, x, y, w, h)
 global(dial_position_color_r, dial_position_color_g, dial_position_color_b,
        gfx_x, gfx_y)
 local(s, ds, cx, cy, ly, ww, hh, v)
@@ -3596,7 +3613,7 @@ local(s, ds, cx, cy, ly, ww, hh, v)
 
   ly = y;
   loop(w,
-    v = time_func(s) / (2*s);
+    v = time_func(func, s) / (2*s);
     cy = y + h * v;
 //    cy = min(y + h, max(y, cy));
     s += ds;
@@ -3979,15 +3996,26 @@ local(length_in_samples, len, ptr, hh, xp, ym, step, minacc, maxacc, ww, hh)
   tapeStopToggle.drawToggle(cX - knobSize, cY - knobSize, 0.15*knobSize, 0.15*knobSize, advanced_tapestop, row_color_r, row_color_g, row_color_b, widget_a, row_color_r, row_color_g*2, row_color_b, toggle_a, "Curve controls for tape stop.");
   advanced_tapestop = tapeStopToggle.processMouseToggle(mouse_x, mouse_y, mouse_cap);
   
-  tapestopShapeKnob.knob_set_display(NORMALIZED_SLIDER, tapestop_enabled && advanced_tapestop);
-  tapestopShapeKnob.drawAndProcess(cX, cY, knobSize, "Shape", "Tapestop modulation shape.", current_tapestop_shape, 1, 1, 1);
+  sprintf(CUSTOM_SLIDER, "%d", tapestopShapeKnob.value * tapestopShapeKnob.scale + 1);
+  timeline_tapestop ? (
+    tapestopShapeKnob.mod1 = 0;
+    tapestopShapeKnob.mod2 = 0;
+    tapestopShapeKnob.knob_set_display(CUSTOM_SLIDER, tapestop_enabled && advanced_tapestop);
+    tapestopShapeKnob.drawAndProcess(cX, cY, knobSize, "Shape", "Tapestop modulation shape.", current_tapestop_shape, 0, 0, 0);
+  ) : (
+    tapestopShapeKnob.knob_set_display(CUSTOM_SLIDER, tapestop_enabled && advanced_tapestop);
+    tapestopShapeKnob.drawAndProcess(cX, cY, knobSize, "Shape", "Tapestop modulation shape.", current_tapestop_shape, 1, 1, 1);
+  );
+
+  tapeStopTimeline.drawToggle(cX + knobSize - 1, cY - knobSize, 0.15*knobSize, 0.15*knobSize, timeline_tapestop, row_color_r, row_color_g, row_color_b, widget_a, row_color_r, row_color_g*2, row_color_b, toggle_a, "Set shape on the timeline.");
+  timeline_tapestop = tapeStopTimeline.processMouseToggle(mouse_x, mouse_y, mouse_cap);
        
   cX += 2.5*knobSize;
   tapestopDepthKnob.knob_set_display(NORMALIZED_SLIDER, tapestop_enabled && advanced_tapestop);
-  tapestopDepthKnob.drawAndProcess(cX, cY, knobSize, "Depth", "Modulation depth.", current_tapestop_depth, 1, 1, 1);
+  tapestopDepthKnob.drawAndProcess(cX, cY, knobSize, "Strength", "Modulation depth.", current_tapestop_depth, 1, 1, 1);
 
   cX += 1.5*knobSize;  
-  time_func_draw(cX, cY - 0.75 * knobSize, knobSize * 3.25, knobSize * 2);
+  time_func_draw(tapestopShapeKnob.value * tapestopShapeKnob.scale, cX, cY - 0.75 * knobSize, knobSize * 3.25, knobSize * 2);
 ) : ( selected_details == 11 ) ? (
   // Tonal delay
   min_degrade = 3;

--- a/SequencedFX/SequencedFX.jsfx
+++ b/SequencedFX/SequencedFX.jsfx
@@ -1,8 +1,8 @@
 desc:Saike SEQS (Sequenced FX) (beta)
 tags: time-based effect
-version: 0.75
+version: 0.76
 author: Joep Vanlier
-changelog: fix bug interaction slowdown and tapestop
+changelog: Allow learning power buttons and various other controls. Allow randomizing modulator A and B.
 license: MIT
 provides:
   seqs_dependencies/*
@@ -92,7 +92,7 @@ import saike_seqs_pitchlib.jsfx-inc
 
 @init
 gfx_ext_retina = 1;
-CURRENT_VERSION = 6;
+CURRENT_VERSION = 7;
 version = CURRENT_VERSION;
 DRAG_STRING = 50;
 DRAG_BLOCK = 1;
@@ -178,6 +178,29 @@ local(func)
     (8 * current_tapestop_depth * exp(-8 * t)) * t * (1.0 - exp(-13 * t)) * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t))
   ) : (func < 7) ? (
     t - t * (0.5 + 0.5 * cos(8 * current_tapestop_depth * $pi * t)) * exp(-3 * t)
+  );
+);
+
+function randomize_row_modulator(mem, n_segments)
+local(ptr, val, last_val, mode, idx)
+global()
+(
+  mode = rand();
+  idx = val = last_val = 0;
+  ptr = mem;
+  
+  loop(n_segments - 1,
+    last_val = val;
+    val = rand();
+    (mode < 0.25) ? (
+      val /= (1.0 + idx % 4);
+    ) : (mode < 0.5) ? (
+      val *= val;
+    );
+    
+    ptr[] = val;
+    ptr += 1;
+    idx += 1;
   );
 );
 
@@ -1374,9 +1397,17 @@ tapestopDepthKnob.serialize_knob();
 tapestopShapeKnob.serialize_knob();
 
 ((!writing) && (last_read_version < 6)) ? (
-  advanced_tapestop = 0;
+  advanced_tapestop = 1;
 ) : (
   file_var(0, advanced_tapestop);
+);
+
+((!writing) && (last_read_version < 7)) ? (
+  randomizing_modulator_a = 0;
+  randomizing_modulator_b = 0;
+) : (
+  file_var(0, randomizing_modulator_a);
+  file_var(0, randomizing_modulator_b);
 );
 
 update_current_levels();
@@ -2029,6 +2060,11 @@ global(chunk_duration_b)
 
 // Delayed sequences to accomodate for crossfades
 (reset_index != last_reset_index) ? (
+  (reset_index == 0) ? (
+    randomizing_modulator_a ? randomize_row_modulator(modulator1_values, n_segments);
+    randomizing_modulator_b ? randomize_row_modulator(modulator2_values, n_segments);
+  );
+
   reset_enabled ? (
     reset = abs(reset_values[reset_index]);
     ((reset > 0) || (reset_index == 0)) ? (
@@ -2837,29 +2873,6 @@ global()
   );
 );
 
-function randomize_row_modulator(mem, n_segments)
-local(ptr, val, last_val, mode, idx)
-global()
-(
-  mode = rand();
-  idx = val = last_val = 0;
-  ptr = mem;
-  
-  loop(n_segments - 1,
-    last_val = val;
-    val = rand();
-    (mode < 0.25) ? (
-      val /= (1.0 + idx % 4);
-    ) : (mode < 0.5) ? (
-      val *= val;
-    );
-    
-    ptr[] = val;
-    ptr += 1;
-    idx += 1;
-  );
-);
-
 function mouse_wheel_values(mem, idx, n_segments, max_value)
 local(start_idx, end_idx, ptr, old, value)
 global(mouse_wheel)
@@ -3009,6 +3022,7 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
             drag_ref_x = 1 - slider(power_slider);
             drag_ref_y = me;
             slider(power_slider) = drag_ref_x;
+            slider_automate(slider(power_slider));
           ) : (mouse_x < x) ? (
             (randomize_toggle.value) ? (
               // Randomize drag
@@ -3174,7 +3188,7 @@ global(label_width, block_width, block_spacing, selected_details,
        randomize_toggle.value
        resize_drag.handle_drag_y_resize)
 local(txt_w, txt_h, ptr, idx, target, y_over, last, current, active_r, active_g, active_b, offset, drag_min, drag_max)
-instance(start_idx, h, subdiv, snap)
+instance(start_idx, h, subdiv, snap, randomize)
 (
   h == 0 ? h = height;
   subdiv == 0 ? subdiv = 12;
@@ -3224,11 +3238,26 @@ instance(start_idx, h, subdiv, snap)
   gfx_x = x + 0.5 * (block_width + block_spacing - txt_w);
   gfx_printf("12");
   gfx_setfont(BASE_FONT);
+
+  gfx_setfont(MOD_FONT);
+  gfx_set(font_r, font_r, font_r, 0.1 + 0.9 * randomize);
+  gfx_measurestr("R", txt_w, txt_h);
+  gfx_x = x + 0.5 * (block_width + block_spacing - txt_w);
+  gfx_y = y + h - txt_h - 2;
+  gfx_printf("R");
+  gfx_setfont(BASE_FONT);
   
   (mouse_x > x) && y_over && (mouse_x < (x + block_width)) ? (
-    hinter.updateHintTime("Enable snap");
-    (mouse_cap == 1) && (last_cap == 0) ? (
-      snap = 1.0 - snap;
+    (mouse_y < (y + 0.5 * h)) ? (
+      hinter.updateHintTime("Enable snap");
+      (mouse_cap == 1) && (last_cap == 0) ? (
+        snap = 1.0 - snap;
+      );
+    ) : (
+      hinter.updateHintTime("Randomize pattern every time\nthe sequencer reset.");
+      (mouse_cap == 1) && (last_cap == 0) ? (
+        randomize = 1.0 - randomize;
+      );
     );
   );
   
@@ -3279,14 +3308,10 @@ draw_logo(12 * (1+scaling), 10 * (1+scaling), 6 * (1+scaling), 6 * (1+scaling));
 gfx_set(1, 1, 1, .1);
 gfx_x = 150 * (1+scaling);
 gfx_y = 30 * (1+scaling);
-gfx_printf("v0.75");
+gfx_printf("v0.76");
 
 scope_w = ceil((block_width + block_spacing) * 33);
 scope_h = 35 * (1 + scaling);
-
-// REMOVE BEFORE FLIGHT
-//grid_origin_y = 00;
-//grid_origin_x = 00;
 
 gfx_x = grid_origin_x + label_width + block_width + block_spacing;
 gfx_y = grid_origin_y;
@@ -3343,13 +3368,17 @@ y_current = draw_effect(14, effect8);
 y_current = draw_effect(15, effect9);
 y_current = draw_effect(16, effect10);
 
+modrow1.randomize = randomizing_modulator_a;
 y_current = modrow1.process_modulation_row(3, 2, 50, modulator1_values, x_current, y_current, 2 * block_width, "Modulator A", "Modulator");
+randomizing_modulator_a = modrow1.randomize;
 mod2_color_r = row_color_r * 2;
 mod2_color_g = row_color_g * 2;
 mod2_color_b = row_color_b * 2;
 mod2_color_a = 1.0;
 
+modrow2.randomize = randomizing_modulator_b;
 y_current = modrow2.process_modulation_row(14, 3, 51, modulator2_values, x_current, y_current, 2 * block_width, "Modulator B", "Modulator");
+randomizing_modulator_b = modrow2.randomize;
 mod3_color_r = row_color_r * 2;
 mod3_color_g = row_color_g * 2;
 mod3_color_b = row_color_b * 2;
@@ -3359,7 +3388,6 @@ gfx_set(0, 0, 0, .6);
 gfx_rect(grid_origin_x + label_width + (block_width + block_spacing) * (loop_point + 1) - 2, grid_origin_y, (n_segments - loop_point) * (block_width + block_spacing) + 1, y_current - grid_origin_y);
 
 handle_effect_drag(fixed_effects, free_effects);
-
 
 gfx_set(1, 1, 1, .1);
 gfx_rect(grid_origin_x + label_width - block_spacing + (block_width + block_spacing) * floor(current_sample / samples_per_beat + 1), grid_origin_y, block_width, y_current - y_s);
@@ -3524,7 +3552,7 @@ local(norm_current)
     this.knob_processMouse(mouse_x, mouse_y, mouse_cap, (default - min_value)/scale ) ? (
       slider_idx > 0 ? (
         slider(slider_idx) = scale * value + min_value;
-        slider_automate(slider_idx);
+        slider_automate(slider(slider_idx));
       );
       update_current_levels();
       dragging = 1;


### PR DESCRIPTION
This PR adds:
- Automatic modulator randomization.
![randomizer](https://user-images.githubusercontent.com/19836026/140990798-149549ae-209f-409c-afab-bf6af10aedb0.gif)
- More tapestop curves.
![curves](https://user-images.githubusercontent.com/19836026/140990785-d4626964-d26e-4f96-bf1f-975daf63a657.gif)
- Dry/Wet control for playhead features (one shared between all for now).