### PR TITLE
seqs / midi_arp: support probabilities in sequencing stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Features:
 - Select pattern by incoming MIDI note.
 - Choose to set times in the plugin by time or beats.
 - Randomize tracks.
+- Copy pasting patterns or blocks.
+- Effect probabilities (ctrl + mouse scrollwheel).
 - Choose from a large number of effects:
   - Effects that modify the playhead: Slowdown, Tape stop, Retrigger, Reverse.
   - Chorus / Phaser / Flaser module.

--- a/SequencedFX/SequencedFX.jsfx
+++ b/SequencedFX/SequencedFX.jsfx
@@ -1,8 +1,8 @@
 desc:Saike SEQS (Sequenced FX) (beta)
 tags: time-based effect
-version: 0.105
+version: 0.106
 author: Joep Vanlier
-changelog: Allow upscaling
+changelog: Add probabilities.
 license: MIT
 provides:
   seqs_dependencies/*
@@ -78,6 +78,7 @@ slider64:midi_note_pattern_select=120<0,127,1>-First Pattern
 
 options:maxmem=34000000
 options:no_meter
+options:want_all_kb
 in_pin:left input
 in_pin:right input
 out_pin:left output
@@ -2261,6 +2262,26 @@ reset_sample = current_sample + crossfade_samples;
 reset_sample > loop_length ? reset_sample -= loop_length;
 reset_index = floor(to_index * reset_sample);
 
+function apply_probability(x)
+local(value, probability, sgn)
+global()
+(
+  sgn = (x == 0) ? 1 : sign(x);
+  value = abs(x) & 31;
+  
+  // Only positive values are impacted by probability
+  value > 0 ? (
+    probability = (x & 480) >> 5;
+    (rand() * 16) <= probability ? (
+      value = 0;
+    );
+  );
+  
+  sgn * value
+);
+
+// test = apply_probability(1 + (15 << 5));
+
 //////////////////////////////////////////////////////////////////////////
 // SEQUENCER HANDLING
 function seek_next(position, continue_until, max_value)
@@ -2289,7 +2310,8 @@ just_started || (reset_index != last_reset_index) ? (
   );
 
   reset_enabled ? (
-    reset = abs(reset_values[reset_index]);
+    reset = abs(apply_probability(reset_values[reset_index]));
+    reset = apply_probability(reset);
     ((reset > 0) || (reset_index == 0)) ? (
       // New target position is now
       target_position = 0;
@@ -2400,7 +2422,7 @@ just_started ? (
 // Non delayed sequences
 (sequencer_index != last_sequencer_index) ? (
   slowdown_enabled ? (
-    speed = abs(speed_values[sequencer_index]);
+    speed = abs(apply_probability(speed_values[sequencer_index]));
     
     // Fractional speed
     (slowdown_scaling == 1) ? (
@@ -2415,7 +2437,7 @@ just_started ? (
   ) : ( speed = 1 );
   
   // Reverse it?
-  (reverse_enabled && abs(reverse_values[sequencer_index]) == 1) ? speed = -speed;
+  (reverse_enabled && abs(apply_probability(reverse_values[sequencer_index])) == 1) ? speed = -speed;
   
   // Calculate the actual offset speed.
   // This is given by - (relative_speed - speed of incoming audio)
@@ -2423,7 +2445,7 @@ just_started ? (
   speed = 1.0 - speed;
   
   previous_filter_target = filter_target;
-  filter_target = filt_values[sequencer_index];
+  filter_target = apply_probability(filt_values[sequencer_index]);
   filter_target == 1 ? (
     filter.filter_envelope.reset = 0;
     filter.filter_envelope.reset_envelope();
@@ -2431,7 +2453,7 @@ just_started ? (
   filter_target = abs(filter_target);
   
   previous_filter2_target = filter2_target;
-  filter2_target = filt2_values[sequencer_index];
+  filter2_target = apply_probability(filt2_values[sequencer_index]);
   filter2_target == 1 ? (
     filter2.filter_envelope.reset = 0;
     filter2.filter_envelope.reset_envelope();
@@ -2439,7 +2461,7 @@ just_started ? (
   filter2_target = abs(filter2_target);
   
   previous_modulation = modulation_target;
-  modulation_target = modulation_fx_values[sequencer_index];
+  modulation_target = apply_probability(modulation_fx_values[sequencer_index]);
   modulation_target == 1 ? (
     modulation_effect.envelope.reset = 0;
     modulation_effect.envelope.reset_envelope();
@@ -2447,23 +2469,23 @@ just_started ? (
   );
   filter2_target = abs(filter2_target);
   
-  gate_target = gate_values[sequencer_index];
+  gate_target = apply_probability(gate_values[sequencer_index]);
   gate_target == 1 ? (
     gate_envelope.reset = 0;
     gate_envelope.reset_envelope();
   );
   gate_target = abs(gate_target);
   
-  reverb_target = reverb_values[sequencer_index];
+  reverb_target = apply_probability(reverb_values[sequencer_index]);
   reverb_target == 1 ? (
     verb_envelope.reset = 0;
     verb_envelope.reset_envelope();
   );
   reverb_target = abs(reverb_target);
   
-  degrade_target = abs(degrade_values[sequencer_index]);
+  degrade_target = abs(apply_probability(degrade_values[sequencer_index]));
   
-  tapestop_target = tapestop_enabled ? tapestop_values[sequencer_index] : 0;
+  tapestop_target = tapestop_enabled ? apply_probability(tapestop_values[sequencer_index]) : 0;
   (tapestop_target > 0) ? (
     tapestop_envelope.calc_times_universal(current_tapestop_decay, current_tapestop_decay, 0);
     stop_factor = 1;
@@ -2476,11 +2498,11 @@ just_started ? (
   );
   tapestop_target = abs(tapestop_target);
   
-  karplus_target = abs(karplus_values[sequencer_index]);
-  pitch_shifter_target = abs(pitch_shifter_values[sequencer_index]);
-  freq_pitch_shifter_target = abs(freq_pitch_shifter_values[sequencer_index]);
-  delay_target = abs(delay_values[sequencer_index]);
-  chorus_target = abs(chorus_values[sequencer_index]);
+  karplus_target = abs(apply_probability(karplus_values[sequencer_index]));
+  pitch_shifter_target = abs(apply_probability(pitch_shifter_values[sequencer_index]));
+  freq_pitch_shifter_target = abs(apply_probability(freq_pitch_shifter_values[sequencer_index]));
+  delay_target = abs(apply_probability(delay_values[sequencer_index]));
+  chorus_target = abs(apply_probability(chorus_values[sequencer_index]));
   
   dyn_speed = speed;
   
@@ -2922,7 +2944,7 @@ local(label, txt_w, txt_h, power_intensity, power_intensity, rr, gg, bb, er, eg,
   rr = base_r * pv;
   gg = base_g * pv;
   bb = base_b * pv;
-  this.nice_rect_color(x, y, w, h, value != 0 ? sprintf(1, "%d", value) : 0, rr, gg, bb, er, eg, eb);
+  this.nice_rect_color(x, y, w, h, value != 0 ? sprintf(1, "%d", value & 31) : 0, rr, gg, bb, er, eg, eb);
 );
 
 function connecting_rect(x, y, w, h, value, powered, base_r, base_g, base_b)
@@ -3151,7 +3173,32 @@ global()
   );
 );
 
-function mouse_wheel_values(mem, idx, n_segments, max_value)
+function change_value(ptr, change, min_value, max_value, is_probability)
+local(old, value, old_sign)
+global()
+(
+  old = ptr[];
+  old_sign = old == 0 ? 1 : sign(old);
+  is_probability ? (
+    // Second 4 bits are used for probability
+    value = ((abs(old) & 480) >> 5) - change;
+    value = min(max(0, value), 15);
+    
+    // Overwrite second bits
+    old = old_sign * ((abs(old) - (abs(old) & 480) + (value << 5)));
+  ) : (
+    // First 5 value bits are used for base effect
+    value = (abs(old) & 31) + change;
+    value = min(max(min_value, value), max_value);
+    
+    // If the value is zero, we just wipe it all, since probability makes no sense for "no effect"
+    // Otherwise, we overwrite first value bits with new data
+    old = value == 0 ? 0 : old_sign * (abs(old) - (abs(old) & 31) + value);
+  );
+  old
+);
+
+function mouse_wheel_values(mem, idx, n_segments, max_value, is_probability)
 local(start_idx, end_idx, ptr, old, value)
 global(mouse_wheel)
 (
@@ -3176,10 +3223,7 @@ global(mouse_wheel)
       
       ptr = mem + start_idx;
       loop(end_idx - start_idx,
-        old = ptr[];
-        value = abs(old) + sign(mouse_wheel);
-        value = min(max(1, value), max_value);
-        ptr[] = sign(old) * value;
+        ptr[] = change_value(ptr, sign(mouse_wheel), 1, max_value, is_probability);
         ptr += 1;
       );
     );
@@ -3271,8 +3315,8 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   shift_drag(y_over, me, mem, idx);
   
   // Allow increasing / decreasing value by mouse_wheel
-  y_over && (idx > 0 && idx < n_segments) ? (
-    mouse_wheel_values(mem, idx, n_segments, max_value);
+  y_over && (idx > -1 && idx < n_segments) ? (
+    mouse_wheel_values(mem, idx, n_segments, max_value, (mouse_cap & 16) > 0);
   );
  
   // Drag out new items
@@ -3336,11 +3380,9 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
       start_idx = ptr;
       // Left or right mouse drag
       captured_by > 0 ? (
-        target = ((last_cap & 4) > 0) ? 0 : abs(mem[ptr]) + 1;
-        target > max_value ? target = max_value;
+        target = ((last_cap & 4) > 0) ? 0 : change_value(mem + ptr, 1, 0, max_value, 0);// abs(mem[ptr]) + 1;
       ) : (
-        target = abs(mem[ptr]) - 1;
-        target < 0 ? target = 0; // max_value;
+        target = change_value(mem + ptr, - 1, 0, max_value, 0); //abs(mem[ptr]) - 1;
       );
       // Negative values mean a continuation
       mem[ptr] = target;
@@ -4782,3 +4824,4 @@ critical_error ? (
   gfx_printf("PLEASE NOTIFY ME OF THIS");
 );
 
+gfx_getchar();

--- a/SequencedFX/SequencedFX.jsfx
+++ b/SequencedFX/SequencedFX.jsfx
@@ -1,8 +1,8 @@
 desc:Saike SEQS (Sequenced FX) (beta)
 tags: time-based effect
-version: 0.106
+version: 0.107
 author: Joep Vanlier
-changelog: Add probabilities.
+changelog: Add implementation of effect probabilities. Hold CTRL or command key to change probabilities. Made tooltip more informative.
 license: MIT
 provides:
   seqs_dependencies/*
@@ -2265,19 +2265,21 @@ reset_index = floor(to_index * reset_sample);
 function apply_probability(x)
 local(value, probability, sgn)
 global()
+instance(status)
 (
   sgn = (x == 0) ? 1 : sign(x);
   value = abs(x) & 31;
   
-  // Only positive values are impacted by probability
-  value > 0 ? (
+  // Probabilistic decision is made on start of block only!
+  x > 0 ? (
+    status = 1;
     probability = (x & 480) >> 5;
-    (rand() * 16) <= probability ? (
-      value = 0;
+    ((16 * rand()) <= probability) ? (
+      status = 0;
     );
   );
   
-  sgn * value
+  sgn * value * status
 );
 
 // test = apply_probability(1 + (15 << 5));
@@ -2310,8 +2312,7 @@ just_started || (reset_index != last_reset_index) ? (
   );
 
   reset_enabled ? (
-    reset = abs(apply_probability(reset_values[reset_index]));
-    reset = apply_probability(reset);
+    reset = abs(reset_prob.apply_probability(reset_values[reset_index]));
     ((reset > 0) || (reset_index == 0)) ? (
       // New target position is now
       target_position = 0;
@@ -2331,7 +2332,7 @@ just_started || (reset_index != last_reset_index) ? (
   
   retrigger_enabled ? (
     // If positive, seek to last negative with the same value.
-    retrig = retrig_values[reset_index];
+    retrig = retrig_prob.apply_probability(retrig_values[reset_index]);
     
     retrig > 0 ? (
       jump_schedule.reset_jump();
@@ -2422,7 +2423,7 @@ just_started ? (
 // Non delayed sequences
 (sequencer_index != last_sequencer_index) ? (
   slowdown_enabled ? (
-    speed = abs(apply_probability(speed_values[sequencer_index]));
+    speed = abs(speed_prob.apply_probability(speed_values[sequencer_index]));
     
     // Fractional speed
     (slowdown_scaling == 1) ? (
@@ -2437,7 +2438,7 @@ just_started ? (
   ) : ( speed = 1 );
   
   // Reverse it?
-  (reverse_enabled && abs(apply_probability(reverse_values[sequencer_index])) == 1) ? speed = -speed;
+  (reverse_enabled && abs(reverse_prob.apply_probability(reverse_values[sequencer_index])) == 1) ? speed = -speed;
   
   // Calculate the actual offset speed.
   // This is given by - (relative_speed - speed of incoming audio)
@@ -2445,7 +2446,7 @@ just_started ? (
   speed = 1.0 - speed;
   
   previous_filter_target = filter_target;
-  filter_target = apply_probability(filt_values[sequencer_index]);
+  filter_target = filt1_prob.apply_probability(filt_values[sequencer_index]);
   filter_target == 1 ? (
     filter.filter_envelope.reset = 0;
     filter.filter_envelope.reset_envelope();
@@ -2453,7 +2454,7 @@ just_started ? (
   filter_target = abs(filter_target);
   
   previous_filter2_target = filter2_target;
-  filter2_target = apply_probability(filt2_values[sequencer_index]);
+  filter2_target = filt2_prob.apply_probability(filt2_values[sequencer_index]);
   filter2_target == 1 ? (
     filter2.filter_envelope.reset = 0;
     filter2.filter_envelope.reset_envelope();
@@ -2461,7 +2462,7 @@ just_started ? (
   filter2_target = abs(filter2_target);
   
   previous_modulation = modulation_target;
-  modulation_target = apply_probability(modulation_fx_values[sequencer_index]);
+  modulation_target = modfx_prob.apply_probability(modulation_fx_values[sequencer_index]);
   modulation_target == 1 ? (
     modulation_effect.envelope.reset = 0;
     modulation_effect.envelope.reset_envelope();
@@ -2469,23 +2470,23 @@ just_started ? (
   );
   filter2_target = abs(filter2_target);
   
-  gate_target = apply_probability(gate_values[sequencer_index]);
+  gate_target = gate_prob.apply_probability(gate_values[sequencer_index]);
   gate_target == 1 ? (
     gate_envelope.reset = 0;
     gate_envelope.reset_envelope();
   );
   gate_target = abs(gate_target);
   
-  reverb_target = apply_probability(reverb_values[sequencer_index]);
+  reverb_target = reverb_prob.apply_probability(reverb_values[sequencer_index]);
   reverb_target == 1 ? (
     verb_envelope.reset = 0;
     verb_envelope.reset_envelope();
   );
   reverb_target = abs(reverb_target);
   
-  degrade_target = abs(apply_probability(degrade_values[sequencer_index]));
+  degrade_target = abs(degrade_prob.apply_probability(degrade_values[sequencer_index]));
   
-  tapestop_target = tapestop_enabled ? apply_probability(tapestop_values[sequencer_index]) : 0;
+  tapestop_target = tapestop_enabled ? tapestop_prob.apply_probability(tapestop_values[sequencer_index]) : 0;
   (tapestop_target > 0) ? (
     tapestop_envelope.calc_times_universal(current_tapestop_decay, current_tapestop_decay, 0);
     stop_factor = 1;
@@ -2498,11 +2499,11 @@ just_started ? (
   );
   tapestop_target = abs(tapestop_target);
   
-  karplus_target = abs(apply_probability(karplus_values[sequencer_index]));
-  pitch_shifter_target = abs(apply_probability(pitch_shifter_values[sequencer_index]));
-  freq_pitch_shifter_target = abs(apply_probability(freq_pitch_shifter_values[sequencer_index]));
-  delay_target = abs(apply_probability(delay_values[sequencer_index]));
-  chorus_target = abs(apply_probability(chorus_values[sequencer_index]));
+  karplus_target = abs(karplus_prob.apply_probability(karplus_values[sequencer_index]));
+  pitch_shifter_target = abs(pitchshift_prob.apply_probability(pitch_shifter_values[sequencer_index]));
+  freq_pitch_shifter_target = abs(freq_shift_prob.apply_probability(freq_pitch_shifter_values[sequencer_index]));
+  delay_target = abs(delay_prob.apply_probability(delay_values[sequencer_index]));
+  chorus_target = abs(chorus_prob.apply_probability(chorus_values[sequencer_index]));
   
   dyn_speed = speed;
   
@@ -2699,6 +2700,7 @@ current_master_db += d_master_gain;
 
 @gfx 1009 755
 current_cursor = randomize_toggle.value ? 32515 : 32512;
+change_proba = (mouse_cap & 4) > 0;
 
 function convert_tempos(target_sync_mode)
 local()
@@ -2924,7 +2926,7 @@ global(font_r, font_g, font_b, gfx_x, gfx_y)
   
   label > 0 ? (
     gfx_measurestr(label, txt_w, txt_h);
-    gfx_x = x - 0.5 * (txt_w - w);
+    gfx_x = x - ceil(0.5 * (txt_w - w));
     gfx_y = y - 0.5 * (txt_h - h);
     gfx_set(font_r, font_g, font_b, 1.0);
     gfx_printf(label);
@@ -2944,7 +2946,7 @@ local(label, txt_w, txt_h, power_intensity, power_intensity, rr, gg, bb, er, eg,
   rr = base_r * pv;
   gg = base_g * pv;
   bb = base_b * pv;
-  this.nice_rect_color(x, y, w, h, value != 0 ? sprintf(1, "%d", value & 31) : 0, rr, gg, bb, er, eg, eb);
+  this.nice_rect_color(x, y, w, h, value != 0 ? sprintf(1, "%d", value) : 0, rr, gg, bb, er, eg, eb);
 );
 
 function connecting_rect(x, y, w, h, value, powered, base_r, base_g, base_b)
@@ -3246,8 +3248,8 @@ global(label_width, block_width, block_spacing, selected_details,
        row_color_r, row_color_g, row_color_b, printed_value,
        start_idx, selected_row, dragging, drag_mode, current_cursor, drag_row_index, drag_color_idx, DRAG_STRING, drag_ref_x, drag_ref_y,
        DRAG_EFFECT, DRAG_NUDGE, DRAG_BLOCK, DRAG_SOLO,
-       randomize_toggle.value)
-local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, active_r, active_g, active_b)
+       randomize_toggle.value, change_proba)
+local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, active_r, active_g, active_b, cur_height, tmp)
 (
   set_row_color(row_index);
   nice_rect(x, y, label_width - 1, block_width, 0, slider(power_slider), row_color_r * .8, row_color_g * .8, row_color_b * .8);
@@ -3275,14 +3277,21 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   x += block_width;
   ptr = mem;
   target = 0;
-  connect_size = 1.5 * (1 + scaling);
+  connect_size = 2.5 * (1 + scaling);
   loop(n_segments,
     current = ptr[];
+
+    tmp = (abs(current) & 480) >> 5;
+    cur_height = block_width * tmp / 16;
     abs(current) > 0 ? (
       active_r = row_color_r;
       active_g = row_color_g;
       active_b = row_color_b;
-      printed_value = max_value > 1 && slider(power_slider) ? abs(current) : 0;
+      change_proba ? (
+        printed_value = slider(power_slider) ? (100 - 100 * tmp / 16) : 0;
+      ) : (
+        printed_value = max_value > 1 && slider(power_slider) ? abs(current) & 31 : 0;
+      );
     ) : (
       active_r = base_r;
       active_g = base_g;
@@ -3292,8 +3301,10 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
     (abs(last) == abs(current)) && (current < 0) ? (
       nice_rect(x, y, block_width, block_width, printed_value, slider(power_slider), active_r, active_g, active_b);
       connecting_rect(x - connect_size, y + 1, 2 * connect_size, block_width - 1, printed_value, slider(power_slider), active_r, active_g, active_b);
+      gfx_set(0, 0, 0, 0.5); gfx_rect(x - connect_size, y, block_width + 2 * connect_size, cur_height);
     ) : (
       nice_rect(x, y, block_width, block_width, printed_value, slider(power_slider), active_r, active_g, active_b);
+      gfx_set(0, 0, 0, 0.5); gfx_rect(x, y, block_width, cur_height);
     );
     target == 0 ? (gfx_set(1.0, 1.0, 1.0, 0.05); gfx_rect(x, y, block_width, block_width));
     x += block_spacing + block_width;
@@ -3304,7 +3315,9 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   
   y_over = (mouse_y > y) && (mouse_y < (y + block_width));
   
-  mouse_x < x && y_over ? hinter.updateHintTime(hint);
+  mouse_x < x && y_over ? hinter.updateHintTime(
+    sprintf(32,"%s%s", hint, "\n\nWhen hovering over pattern:\nLMB - Create block\nRMB - remove block\nCTRL + LMB - Remove blocks\nAlt + LMB - Nudge row\nCTRL + ALT + LMB - Nudge all\nShift + Drag - Drag block\nShift + RMB - Copy/paste block\nCtrl + Scrollwheel - Alter note probability")
+  );
   
   (captured_by == me) ? dragging = 1;
   
@@ -3316,7 +3329,7 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   
   // Allow increasing / decreasing value by mouse_wheel
   y_over && (idx > -1 && idx < n_segments) ? (
-    mouse_wheel_values(mem, idx, n_segments, max_value, (mouse_cap & 16) > 0);
+    mouse_wheel_values(mem, idx, n_segments, max_value, change_proba);
   );
  
   // Drag out new items
@@ -3629,7 +3642,7 @@ draw_logo(12 * (1+scaling), 10 * (1+scaling), 6 * (1+scaling), 6 * (1+scaling));
 gfx_set(1, 1, 1, .1);
 gfx_x = 150 * (1+scaling);
 gfx_y = 30 * (1+scaling);
-gfx_printf("v0.105");
+gfx_printf("v0.107");
 
 scope_w = ceil((block_width + block_spacing) * 33);
 scope_h = 35 * (1 + scaling);

--- a/saike_midi_arp/saike_midi_arp.jsfx
+++ b/saike_midi_arp/saike_midi_arp.jsfx
@@ -1,8 +1,8 @@
 desc:Saike MIDI ARP (beta)
 tags: midi arpeggiator
-version: 0.20
+version: 0.21
 author: Joep Vanlier
-changelog: Fix bug in MIDI handling that would sometimes drop the first note.
+changelog: Added note probabilities. Use mouse scrollwheel to change note probability.
 license: MIT
 provides:
   midi_arp_dependencies/*
@@ -231,7 +231,7 @@ file_version = 3;
 
 @block
 function process_sequence(current_pattern_index, block_position)
-local(current_pattern, idx, current_idx, audio_octave, current_row, new_note, mod, vel)
+local(current_pattern, idx, current_idx, audio_octave, current_row, new_note, mod, vel, to_play)
 global(
   pattern_buffer,
   extra_octaves,
@@ -254,6 +254,7 @@ global(
   cc1_choice, cc2_choice, cc3_choice, cc4_choice,
   min_cc1, min_cc2, min_cc3, min_cc4,
   max_cc1, max_cc2, max_cc3, max_cc4,
+  proba
 )
 (
   (sequencer_index != last_sequencer_index) ? (
@@ -280,14 +281,21 @@ global(
       loop(polyphony,
         current_row = current_pattern + (idx + MAX_POLYPHONY * audio_octave) * max_segments;
         current_idx = idx + MAX_POLYPHONY * audio_octave;
+        to_play = current_row[sequencer_index];
         
-        (current_row[sequencer_index] == 0) ? (
+        // Disable based on probability
+        to_play > 0 ? (
+          proba = to_play % 16; // Get probability
+          (rand() * 15 + 1 < proba) ? to_play = 0;
+        );
+        
+        (to_play == 0) ? (
           // No note / Terminate one if it is playing
           (notes_in_flight[current_idx] > 0) ? (
             midisend(block_position, $x80, notes_in_flight[current_idx], 0);
             notes_in_flight[current_idx] = 0;
           );
-        ) : (current_row[sequencer_index] == 1) ? (
+        ) : (to_play > 0) ? (
           // If something playing, stop before starting new note
           (notes_in_flight[current_idx] > 0) ? (
             midisend(block_position, $x80, notes_in_flight[current_idx], 0);
@@ -363,7 +371,7 @@ micro_view = gfx_ext_flags & 1;
 setup_theme();
 current_cursor = randomize_toggle.value ? 32515 : 32512;
 
-function mouse_wheel_values(mem, idx, n_segments, max_value)
+function mouse_wheel_values(mem, idx, n_segments, max_value, sgn)
 local(start_idx, end_idx, ptr, old, value)
 global(mouse_wheel)
 (
@@ -389,7 +397,7 @@ global(mouse_wheel)
       ptr = mem + start_idx;
       loop(end_idx - start_idx,
         old = ptr[];
-        value = abs(old) + sign(mouse_wheel);
+        value = abs(old) + sgn * sign(mouse_wheel);
         value = min(max(1, value), max_value);
         ptr[] = sign(old) * value;
         ptr += 1;
@@ -464,7 +472,7 @@ global(label_width, block_width, block_spacing, selected_details,
        DRAG_EFFECT, DRAG_NUDGE, DRAG_BLOCK, DRAG_SOLO,
        randomize_toggle.value,
        micro_view)
-local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, active_r, active_g, active_b)
+local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, active_r, active_g, active_b, cur_height)
 (
   x = floor(x);
   set_row_color(row_index);
@@ -488,16 +496,20 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   connect_size = 2 * (1 + scaling) + 2 * micro_view;
   loop(n_segments,
     current = ptr[];
+    cur_height = (abs(current) - 1) * block_width / 16;
     abs(current) > 0 ? (
       active_r = row_color_r;
       active_g = row_color_g;
       active_b = row_color_b;
-      printed_value = max_value > 1 ? abs(current) : 0;
+//      printed_value = max_value > 1 ? abs(current) : 0;
+      printed_value = 0;
       (abs(last) == abs(current)) && (current < 0) ? (
         nice_rect(x, y, block_width, block_width, printed_value, active_r, active_g, active_b);
-        connecting_rect(x - connect_size, y + 1, 2 * connect_size, block_width - 1, printed_value, active_r, active_g, active_b);
+        connecting_rect(x - connect_size, y + 1, 2 * connect_size + 1, block_width - 1, printed_value, active_r, active_g, active_b);
+        gfx_set(0, 0, 0, 0.5); gfx_rect(x - connect_size - 1, y, block_width + 2 * connect_size, cur_height);
       ) : (
         nice_rect(x, y, block_width, block_width, printed_value, active_r, active_g, active_b);
+        gfx_set(0, 0, 0, 0.5); gfx_rect(x, y, block_width, cur_height);
       );
     ) : (
       printed_value = 0;
@@ -519,7 +531,7 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   
   y_over = (mouse_y > y) && (mouse_y < (y + block_width));
    
-  y_over ? hinter.updateHintTime("LMB - Create block\nRMB remove block\nCTRL + LMB - Remove blocks\nAlt + LMB - Nudge row\nCTRL + ALT + LMB - Nudge all");
+  y_over ? hinter.updateHintTime("LMB - Create block\nRMB - remove block\nCTRL + LMB - Remove blocks\nAlt + LMB - Nudge row\nCTRL + ALT + LMB - Nudge all\nShift + Drag - Drag block\nShift + RMB - Copy/paste block\nScrollwheel - Alter note probability");
    
   (captured_by == me) ? dragging = 1;
   
@@ -531,7 +543,7 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
   
   // Allow increasing / decreasing value by mouse_wheel
   y_over && (idx > 0 && idx < n_segments) ? (
-    mouse_wheel_values(mem, idx, n_segments, max_value);
+    mouse_wheel_values(mem, idx, n_segments, max_value, -1);
   );
  
   // Drag out new items
@@ -571,10 +583,10 @@ local(connect_size, txt_w, txt_h, ptr, idx, target, y_over, last, current, activ
       start_idx = ptr;
       // Left or right mouse drag
       captured_by > 0 ? (
-        target = ((last_cap & 4) > 0) ? 0 : abs(mem[ptr]) + 1;
-        target > max_value ? target = max_value;
+        target = ((last_cap & 4) > 0) ? 0 : max(1, abs(mem[ptr]));
+        //target > max_value ? target = max_value;
       ) : (
-        target = abs(mem[ptr]) - 1;
+        target = 0;//abs(mem[ptr]) - 1;
         target < 0 ? target = 0; // max_value;
       );
       // Negative values mean a continuation
@@ -837,7 +849,7 @@ loop(extra_octaves + 1,
   loop(polyphony,
     note = current_arp[polyphony - c_idx - 1];
     label = identify_note(note > 0 ? note + 12 * current_octave : 0);
-    yc = process_effect_row(row_idx, row_idx + 1, current_pattern + (MAX_POLYPHONY * current_octave + polyphony - c_idx - 1) * max_segments, x, yc, label, 1, "");
+    yc = process_effect_row(row_idx, row_idx + 1, current_pattern + (MAX_POLYPHONY * current_octave + polyphony - c_idx - 1) * max_segments, x, yc, label, 15, "");
     row_idx += 1;
     c_idx += 1;
   );


### PR DESCRIPTION
Enables probabilities for both MIDI arp and SEQS.

![proba_midi](https://user-images.githubusercontent.com/19836026/207180973-5350657f-361c-4d1f-8d96-bb24e3f5404f.gif)
![proba_seqs2](https://user-images.githubusercontent.com/19836026/207181558-c8e16841-92ed-4509-aed4-5835aeb0af56.gif)

