### PR TITLE
spectral_analyzer: Improve sonogram display

### DIFF
--- a/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
+++ b/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
@@ -1,8 +1,8 @@
 desc:Saike Spectral Analyzer (beta)
 tags: analysis FFT meter spectrum
-version: 5.0.23
+version: 5.0.24
 author: Joep Vanlier, Trond-Viggo Melssen, Cockos, Feed The Cat
-changelog: Do work on sonogram display (WIP)
+changelog: Make sonogram scale logarithmically. Fix bug with theme display. Don't draw sono grid in TCP/MCP. Switch theme with menu.
 provides: colormaps.jsfx-inc
 Copyright (C) 2007 Cockos Incorporated
 Copyright (C) 2018 Joep Vanlier, Trond-Viggo Melssen
@@ -986,8 +986,8 @@ instance(fmaxFactorf)
 SONOSURFACE2 = 3;
 function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, hp, logarithmic, fmaxFactor)
   instance(w, h, x, y, preSonoDest, preSonoX, preSonoY, sonoSize,sonoSizeX, sonoColorLoc, sonoColorMap, iv, sonosurf, blurred, tx, tl, i, xscale, logarithmic, wsc, cv, norm, fmax)
-  globals(slider44, gfx_dest, gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, fftsize, SONOSURFACE, SONOSURFACE2, gfx_mode)
-  local(val, f, accumulated_step, current_max, stepsize, N)
+  globals(slider44, gfx_dest, gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, fftsize, SONOSURFACE, SONOSURFACE2, gfx_mode, slider2, scale_offset_db_user, micro_view)
+  local(extra_scale, scaling, val, plot_val, f, accumulated_step, current_max, stepsize, N, better_scaling)
 (
   x = xp;
   y = yp;
@@ -1011,6 +1011,9 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
   wsc      = sonoSize/(log(1+.5*fmax*xscale));
   
   // Start by drawing the previous buffer to this one
+  better_scaling = 1;
+  scaling = 0.5 * 20 / log(10);
+  extra_scale = 0.001 * sonoScale;
   ( slider44 == 0 ) ? (
     gfx_dest = sonosurf;
     gfx_setimgdim(sonosurf, sonoSizeX, sonoSize);
@@ -1042,7 +1045,18 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
           
           accumulated_step += stepsize;
           (accumulated_step > 1) ? (
-            sonoColorLoc = sonoColorMap + 3*ceil( (  invert + ( 1 - 2*invert ) * (1-exp(-norm * current_max))  )*255);   
+
+            better_scaling ? (
+              // Maximum value is given by: - scale_offset_db_user
+              // Minimum value is given by: slider2 - scale_offset_db_user
+              plot_val = scaling * log(current_max);
+              plot_val = min(1, max(0, (plot_val - scale_offset_db_user + extra_scale) / slider2));
+              !invert ? plot_val = 1 - plot_val;
+              sonoColorLoc = sonoColorMap + 3 * ceil(255 * plot_val);
+            ) : (
+              sonoColorLoc = sonoColorMap + 3*ceil((invert + (1 - 2 * invert) * (1 - exp(-norm * current_max))) * 255);
+            );
+            
             gfx_setpixel(sonoColorLoc[],sonoColorLoc[1],sonoColorLoc[2]);
             current_max = 0;
             accumulated_step -= 1;
@@ -1056,7 +1070,18 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
         N = 1/N;
         i = sonoSize;
         loop(sonoSize/N,
-          sonoColorLoc = sonoColorMap + 3*ceil(  (  invert + ( 1 - 2*invert ) * (1-exp(-sonogramBuffer[]*sonoScale))  )*255);
+        
+        better_scaling ? (
+          // Maximum value is given by: - scale_offset_db_user
+          // Minimum value is given by: slider2 - scale_offset_db_user
+          plot_val = scaling * log(sonogramBuffer[] * sonoScale);
+          plot_val = min(1, max(0, (plot_val - scale_offset_db_user + extra_scale) / slider2));
+          !invert ? plot_val = 1 - plot_val;
+          sonoColorLoc = sonoColorMap + 3 * ceil(255 * plot_val);
+        ) : (
+          sonoColorLoc = sonoColorMap + 3*ceil((invert + (1 - 2 * invert) * (1 - exp(- sonogramBuffer[] * sonoScale))) * 255);
+        );
+        
           gfx_r = sonoColorLoc[];
           gfx_g = sonoColorLoc[1];
           gfx_b = sonoColorLoc[2];
@@ -1075,8 +1100,17 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
         val = max(val, sonogramBuffer[]);
         
         (tx - tl) > 0.999999 ?
-        (  
-          sonoColorLoc = sonoColorMap + 3*ceil(  (  invert + ( 1 - 2*invert ) * (1-exp(- val*sonoScale))  )*255);
+        (
+          better_scaling ? (
+            // Maximum value is given by: - scale_offset_db_user
+            // Minimum value is given by: slider2 - scale_offset_db_user
+            plot_val = scaling * log(val);
+            plot_val = min(1, max(0, (plot_val - scale_offset_db_user + extra_scale) / slider2));
+            !invert ? plot_val = 1 - plot_val;
+            sonoColorLoc = sonoColorMap + 3 * ceil(255 * plot_val);
+          ) : (
+            sonoColorLoc = sonoColorMap + 3 * ceil((invert + (1 - 2*invert) * (1 - exp(- val * sonoScale))) * 255);
+          );
           val = 0;
           
           gfx_r = sonoColorLoc[];
@@ -1089,30 +1123,6 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
         i += 1;
         sonogramBuffer += 1;
       );
-      
-      // TODO
-      
-/*      tx = log(1.0+((f/srate-spectrum_xoffset)*2.0)*400) * wsc;
-      while(
-        gfx_r=gfx_g=gfx_b=intensity; gfx_a=0.8 * slider39 * slider40;
-        dotext = drawtext && (tx > gfx_x && f!=40 && f!=4000 && f != 15000 &&
-           (f<400 || f >= 1000 || f == 500) && (f<6000 || f>=10000) || (tx-ltxt)>.1*gfx_w);
-        tx > lx ? ( lx=tx+4; gfx_line(tx,spectrum_yoffset,tx,gfx_h - spectrum_yoffsetbottom - (dotext ? 0 : gfx_texth+2),0); );
-        // NOTE: Note that the line above didn't have a rescale Y
-        gfx_r=gfx_g=gfx_b=textintensity; gfx_a=0.9;
-        dotext ? (
-          ltxt = tx;
-          gfx_x = tx + 3;
-          gfx_y = gfx_h-gfx_texth-spectrum_yoffsetbottom;
-          gfx_line( gfx_x-3, gfx_y, gfx_x-3, gfx_y+gfx_texth );
-          f>=1000 ? gfx_printf("%dkHz",f*.001) : gfx_printf("%dHz",f);
-        );
-        f += (f<100?10:f<1000?100:f<10000?1000:5000);
-        tx = log(1.0+((f/srate-spectrum_xoffset)*2.0)*400) * wsc;
-        tx < spectrum_xmax
-      );
-  */    
-      
     );
   );
   
@@ -1139,7 +1149,7 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h);  
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h); */   
   gfx_mode = 0;
-  this.sonoGrid(logarithmic, x, y, w, h, fmaxFactor);
+  !micro_view ? this.sonoGrid(logarithmic, x, y, w, h, fmaxFactor);
 );
 
 function to_x(f)
@@ -1894,9 +1904,16 @@ instance()
     );
 
     slider29 == 0 && cap_last_y != mouse_y ) ? (
-      sonogram.hit_button(mouse_x,mouse_y,-1) ? ( slider32 = cycle_slider(slider32, 0, 7, 1);
+      //sonogram.hit_button(mouse_x,mouse_y,-1) ? ( slider32 = cycle_slider(slider32, 0, 7, 1); );
+      (mouse_y > gfx_h-sono_yoffset_bottom-sono_size) ? (
+        gfx_x = mouse_x;
+        gfx_y = mouse_y;
+        ret = gfx_showmenu("Magma|Magma (inverted)|Viridis|Viridis (inverted)|Inferno|Infero (inverted)|Plasma|Plasma (inverted)");
+        (ret > 0) ? (
+          slider32 = ret - 1;
+        );
+      );
     );
-  );
 ) : (
   ( zoomMode == 1 ) ? (
     zoomMode = 2;
@@ -2075,10 +2092,10 @@ instance()
                  slider42 == 0 ? interpolation_button.hit_button(mouse_x, mouse_y, 51);
                  slider42 == 0 ? diff_mode_button.hit_button(mouse_x, mouse_y, 48);
                  slider42 == 0 ? scaling.hit_button(mouse_x,mouse_y,5);
-                 slider42 == 0 ? colormap.hit_button(mouse_x,mouse_y,7);              
+                 slider42 == 0 && slider43 == 1 ? colormap.hit_button(mouse_x,mouse_y,7);
                  slider42 == 0 ? smoothing_button.hit_button(mouse_x,mouse_y,6);
-                 slider42 == 0 ? alphalevel.hit_button(mouse_x,mouse_y,28);
-                 slider42 == 0 ? background_button.hit_button(mouse_x,mouse_y,30);                 
+                 slider42 == 0 && slider43 == 1 ? alphalevel.hit_button(mouse_x,mouse_y,28);
+                 slider42 == 0 && slider43 == 1 ? background_button.hit_button(mouse_x,mouse_y,30);
                  slider42 == 0 ? sonoScale.hit_button(mouse_x,mouse_y,10) ? :
                  slider42 == 0 ? smoothing_type.hit_button(mouse_x,mouse_y,45);
 

--- a/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
+++ b/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
@@ -1,8 +1,8 @@
 desc:Saike Spectral Analyzer (beta)
 tags: analysis FFT meter spectrum
-version: 5.0.24
+version: 5.0.25
 author: Joep Vanlier, Trond-Viggo Melssen, Cockos, Feed The Cat
-changelog: Make sonogram scale logarithmically. Fix bug with theme display. Don't draw sono grid in TCP/MCP. Switch theme with menu.
+changelog: Improve sonogram layout.
 provides: colormaps.jsfx-inc
 Copyright (C) 2007 Cockos Incorporated
 Copyright (C) 2018 Joep Vanlier, Trond-Viggo Melssen
@@ -62,7 +62,7 @@ slider43:0<0,1,1{disabled,enabled}>-show theme
 slider44:0<0,1,1{disabled,enabled}>-freeze spectrum
 slider45:4<0,4,1{Average,Maximum,Loess,Adaptive,Fast}>-Smoothing method
 
-slider46:sonoGridAlpha=0<0,1,0.001>Sonogram Grid Alpha
+slider46:sonoGridAlpha=0.4<0,1,0.001>-Sonogram Grid Alpha
 slider47:Dummy=0<0,1,1>-Dummy
 slider48:Dummy=0<0,1,1>-Dummy
 slider49:Dummy=0<0,1,1>-Dummy
@@ -320,6 +320,7 @@ file_var(0, kernelSizeB);
 file_var(0, fftSizeB);
 file_var(0, xscaleB);
 file_var(0, showNotes);
+file_var(0, legacy_style);
 
 @slider
 slider2 != lfloor ? old_w=0;
@@ -947,8 +948,8 @@ instance(fmaxFactorf)
     yc = y + h - tx;
     
     gfx_set(0, 0, 0, sonoGridAlpha);    
-    gfx_line(x, yc, x + w, yc + 1);
-    gfx_line(x, yc, x + w, yc - 1);
+    gfx_line(x, yc, x + w, yc + 2);
+    gfx_line(x, yc, x + w, yc - 2);
     
     gfx_set(1, 1, 1, sonoGridAlpha);
     gfx_line(x, yc, x + w, yc);
@@ -984,10 +985,11 @@ instance(fmaxFactorf)
 );
 
 SONOSURFACE2 = 3;
+COLORLEGEND = 5;
 function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, hp, logarithmic, fmaxFactor)
   instance(w, h, x, y, preSonoDest, preSonoX, preSonoY, sonoSize,sonoSizeX, sonoColorLoc, sonoColorMap, iv, sonosurf, blurred, tx, tl, i, xscale, logarithmic, wsc, cv, norm, fmax)
-  globals(slider44, gfx_dest, gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, fftsize, SONOSURFACE, SONOSURFACE2, gfx_mode, slider2, scale_offset_db_user, micro_view)
-  local(extra_scale, scaling, val, plot_val, f, accumulated_step, current_max, stepsize, N, better_scaling)
+  globals(slider44, gfx_dest, gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, fftsize, SONOSURFACE, SONOSURFACE2, COLORLEGEND, gfx_mode, slider2, scale_offset_db_user, micro_view, legacy_style)
+  local(sono_start_x, extra_scale, scaling, val, plot_val, f, accumulated_step, current_max, stepsize, N, better_scaling)
 (
   x = xp;
   y = yp;
@@ -1011,7 +1013,7 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
   wsc      = sonoSize/(log(1+.5*fmax*xscale));
   
   // Start by drawing the previous buffer to this one
-  better_scaling = 1;
+  better_scaling = 1 - legacy_style;
   scaling = 0.5 * 20 / log(10);
   extra_scale = 0.001 * sonoScale;
   ( slider44 == 0 ) ? (
@@ -1126,12 +1128,32 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
     );
   );
   
+  sono_start_x = x;
+  (better_scaling && !micro_view) ? (
+    /* Draw color legend */
+    gfx_dest = COLORLEGEND;
+    gfx_setimgdim(COLORLEGEND, 1, 255);
+    val = 0;
+    loop(255,
+      sonoColorLoc = sonoColorMap + 3 * ceil(min(255, val + extra_scale));
+      gfx_x = 0;
+      gfx_y = val;
+      gfx_setpixel(sonoColorLoc[],sonoColorLoc[1],sonoColorLoc[2]);
+      val += 1;
+    );
+    gfx_dest = 0;
+    sono_start_x += 35;
+  );
+  
+  
   // Draw the sonogram to the screen
   gfx_dest = preSonoDest;
   gfx_x = x;
   gfx_y = y;
   gfx_a = .95;
-  gfx_blit(sonosurf, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h);  
+  gfx_blit(sonosurf, 1, 0, 0, 0, sonoSizeX, sonoSize, sono_start_x, y, w - sono_start_x, h);
+  
+  (better_scaling && !micro_view) ? gfx_blit(COLORLEGEND, 1, 0, 0, 0, 1, 255, x + 5, y + 10, 25, h - 20);
   
   // Blur it in a second buffer
   /*gfx_dest = blurred;
@@ -1149,7 +1171,7 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h);  
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h); */   
   gfx_mode = 0;
-  !micro_view ? this.sonoGrid(logarithmic, x, y, w, h, fmaxFactor);
+  !micro_view ? this.sonoGrid(logarithmic, sono_start_x, y, w, h, fmaxFactor);
 );
 
 function to_x(f)
@@ -1185,7 +1207,7 @@ global()
 
 function drawGrid()
 local(intensity, textintensity,
-      gv, cnt, y, gfx_texth, bottom_line, f, lx, ltxt, tx, dotext, scale_offset, drawtext, f1, f2, color)
+      gv, cnt, y, gfx_texth, bottom_line, f, lx, ltxt, tx, dotext, scale_offset, drawtext, f1, f2, color, text_y)
 global(bgColor, wsc, logf_to_pixels, scale_offset_db,
        gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, gfx_w, gfx_h,
        slider39, slider40, srate,
@@ -1273,11 +1295,22 @@ global(bgColor, wsc, logf_to_pixels, scale_offset_db,
          (f<400 || f >= 1000 || f == 500) && (f<6000 || f>=10000) || (tx-ltxt)>.1*gfx_w);
       tx > lx ? ( lx=tx+4; gfx_line(tx,spectrum_yoffset,tx,gfx_h - spectrum_yoffsetbottom - (dotext ? 0 : gfx_texth+2),0); );
       // NOTE: Note that the line above didn't have a rescale Y
-      gfx_r=gfx_g=gfx_b=textintensity; gfx_a=0.9;
       dotext ? (
         ltxt = tx;
-        gfx_x = tx + 3;
-        gfx_y = gfx_h-gfx_texth-spectrum_yoffsetbottom;
+        
+        gfx_set(0, 0, 0, 1);
+        gfx_x = tx + 2;
+        text_y = gfx_h-gfx_texth-spectrum_yoffsetbottom; gfx_y = text_y;
+        gfx_line( gfx_x-3, gfx_y, gfx_x-3, gfx_y+gfx_texth );
+        f>=1000 ? gfx_printf("%dkHz",f*.001) : gfx_printf("%dHz",f);
+        
+        gfx_x = tx + 4;
+        text_y = gfx_h-gfx_texth-spectrum_yoffsetbottom; gfx_y = text_y + 1;
+        gfx_line( gfx_x-3, gfx_y, gfx_x-3, gfx_y+gfx_texth );
+        f>=1000 ? gfx_printf("%dkHz",f*.001) : gfx_printf("%dHz",f);
+        
+        gfx_r=gfx_g=gfx_b=textintensity; gfx_a=0.9;
+        gfx_x = tx + 3; gfx_y = text_y;
         gfx_line( gfx_x-3, gfx_y, gfx_x-3, gfx_y+gfx_texth );
         f>=1000 ? gfx_printf("%dkHz",f*.001) : gfx_printf("%dHz",f);
       );
@@ -1905,12 +1938,31 @@ instance()
 
     slider29 == 0 && cap_last_y != mouse_y ) ? (
       //sonogram.hit_button(mouse_x,mouse_y,-1) ? ( slider32 = cycle_slider(slider32, 0, 7, 1); );
-      (mouse_y > gfx_h-sono_yoffset_bottom-sono_size) ? (
+      ((mouse_y > gfx_h-sono_yoffset_bottom-sono_size) && (mouse_y < gfx_h - sono_yoffset_bottom)) ? (
         gfx_x = mouse_x;
         gfx_y = mouse_y;
-        ret = gfx_showmenu("Magma|Magma (inverted)|Viridis|Viridis (inverted)|Inferno|Infero (inverted)|Plasma|Plasma (inverted)");
-        (ret > 0) ? (
+        sprintf(64, "%sMagma|%sMagma (inverted)|%sViridis|%sViridis (inverted)|%sInferno|%sInfero (inverted)|%sPlasma|%sPlasma (inverted)|%sLogarithmic|%sShow Grid|%sLegacy style",
+        slider32 == 0 ? "!" : "",
+        slider32 == 1 ? "!" : "",
+        slider32 == 2 ? "!" : "",
+        slider32 == 3 ? "!" : "",
+        slider32 == 4 ? "!" : "",
+        slider32 == 5 ? "!" : "",
+        slider32 == 6 ? "!" : "",
+        slider32 == 7 ? "!" : "",
+        slider33 ? "!" : "",
+        (sonoGridAlpha == 0) ? "": "!",
+        legacy_style ? "!" : ""
+        );
+        ret = gfx_showmenu(64);
+        (ret > 0 && ret < 9) ? (
           slider32 = ret - 1;
+        ) : (ret == 9) ? (
+          slider33 = 1 - slider33;
+        ) : (ret == 10) ? (
+          sonoGridAlpha = (sonoGridAlpha == 0) ? 0.4 : 0;
+        ) : (ret == 11) ? (
+          legacy_style = 1 - legacy_style;
         );
       );
     );
@@ -2857,7 +2909,8 @@ mouse_cap > 0 ? (
       gfx_measurestr("30 Hz", __, yhz);
       gfx_y = gfx_h-sono_yoffset_bottom-sono_size + 1.4 * yhz;
       gfx_x = 5;
-      gfx_printf( "Ch: %d, Sc: %d", selected + 1, slider30 );
+//      gfx_printf( "Ch: %d, Sc: %d", selected + 1, slider30 );
+      !micro_view ? gfx_printf(" %d", selected + 1);
     ) : (
       ( (showSum == 0) || (displayMode == 1) ) ? (
         // Make sure that the sonogram is still updated if it's not currently being rendered.
@@ -2873,7 +2926,8 @@ mouse_cap > 0 ? (
         gfx_measurestr("30 Hz", __, yhz);
         gfx_y = gfx_h - sono_yoffset_bottom-sono_size + 1.2 * yhz;
         gfx_x = 5;
-        gfx_printf( "Sum, Sc: %d", slider30 );
+        // gfx_printf( "Sum, Sc: %d", slider30 );
+        gfx_printf("Sum");
       );
     );
     (!hideUI && !micro_view) ? (
@@ -2881,7 +2935,7 @@ mouse_cap > 0 ? (
       gfx_y = gfx_h-sono_yoffset_bottom-sono_size + 1.4 * yhz + 1.2 * tSkip;
       gfx_x = 5;
       
-      printColorMapName(cmapidx, invert);
+      //printColorMapName(cmapidx, invert);
     );
     gfx_mode = 0;
   );

--- a/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
+++ b/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
@@ -1,8 +1,8 @@
 desc:Saike Spectral Analyzer (beta)
 tags: analysis FFT meter spectrum
-version: 5.0.22
+version: 5.0.23
 author: Joep Vanlier, Trond-Viggo Melssen, Cockos, Feed The Cat
-changelog: Make fewer things overlap on retina displays.
+changelog: Do work on sonogram display (WIP)
 provides: colormaps.jsfx-inc
 Copyright (C) 2007 Cockos Incorporated
 Copyright (C) 2018 Joep Vanlier, Trond-Viggo Melssen
@@ -62,7 +62,7 @@ slider43:0<0,1,1{disabled,enabled}>-show theme
 slider44:0<0,1,1{disabled,enabled}>-freeze spectrum
 slider45:4<0,4,1{Average,Maximum,Loess,Adaptive,Fast}>-Smoothing method
 
-slider46:Dummy=0<0,1,1>-Dummy
+slider46:sonoGridAlpha=0<0,1,0.001>Sonogram Grid Alpha
 slider47:Dummy=0<0,1,1>-Dummy
 slider48:Dummy=0<0,1,1>-Dummy
 slider49:Dummy=0<0,1,1>-Dummy
@@ -915,11 +915,79 @@ function checkChannelButtons()
   hit > 0;
 );
 
+function sonoGrid(logarithmic, x, y, w, h, factor)
+global(spectrum_xmax, srate, gfx_x, gfx_y, sonoGridAlpha)
+local(f, i, tx, fmax, xscale, wsc, txt, xc, sw, sh, yc, last_y)
+instance(fmaxFactorf)
+(
+  f = 0;
+  fmaxFactorf = factor;
+  fmax = srate / factor;
+  xscale = 800 / (fmax - 4);
+  wsc = h / (log(1+.5*fmax*xscale));
+  last_y = -10000;
+  while(
+    logarithmic ? (
+      f += (f<100?10:f<1000?100:f<10000?1000:5000);
+      tx = log(1.0 + f * xscale) * wsc;
+      txt = f < 1000 ? sprintf(14, "%dHz", f) : sprintf(14, "%dkHz", f / 1000);
+    ) : (
+      factor < 1.1 ? (
+        f += 1000;
+        txt = sprintf(14, "%dkHz", f / 1000);
+      ) : ( factor < 2.5 ) ? (
+        f += 500;
+        txt = f < 1000 ? sprintf(14, "%dHz", f) : sprintf(14, "%.1fkHz", f / 1000);
+      ) : (
+        f += (f<100?10:f<1000?100:f<10000?200:5000);
+        txt = f < 1000 ? sprintf(14, "%dHz", f) : sprintf(14, "%.1fkHz", f / 1000);
+      );
+      tx = 2 * (f / fmax) * h;
+    );
+    yc = y + h - tx;
+    
+    gfx_set(0, 0, 0, sonoGridAlpha);    
+    gfx_line(x, yc, x + w, yc + 1);
+    gfx_line(x, yc, x + w, yc - 1);
+    
+    gfx_set(1, 1, 1, sonoGridAlpha);
+    gfx_line(x, yc, x + w, yc);
+  
+    gfx_measurestr(txt, sw, sh);
+    yc = y + h - tx - 0.5 * sh;
+    
+    // Don't print text on top of eachother
+    abs(last_y - yc) > 2 * sh ? (
+      xc = x + 3;
+      gfx_x = xc - 1;
+      gfx_y = yc;
+      gfx_set(0, 0, 0, 1);
+      gfx_printf(txt);
+      gfx_x = xc + 1;
+      gfx_y = yc;
+      gfx_printf(txt);
+      gfx_x = xc;
+      gfx_y = yc - 1;
+      gfx_printf(txt);
+      gfx_x = xc;
+      gfx_y = yc + 1;
+      gfx_printf(txt);
+      gfx_x = xc;
+      gfx_y = yc;
+      gfx_set(1, 1, 1, 1);
+      gfx_printf(txt);
+      last_y = yc;
+    );
+  
+    ((f < srate / 2) && (yc > (y + 3 * sh)))
+  );
+);
+
 SONOSURFACE2 = 3;
 function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, hp, logarithmic, fmaxFactor)
-  instance(w, h, x, y, preSonoDest, preSonoX, preSonoY, sonoSize,sonoSizeX, sonoColorLoc, sonoColorMap, iv, sonosurf, blurred, tx, tl, i, xscale, logarithmic, wsc, cv, N, norm, fmax)
+  instance(w, h, x, y, preSonoDest, preSonoX, preSonoY, sonoSize,sonoSizeX, sonoColorLoc, sonoColorMap, iv, sonosurf, blurred, tx, tl, i, xscale, logarithmic, wsc, cv, norm, fmax)
   globals(slider44, gfx_dest, gfx_r, gfx_g, gfx_b, gfx_a, gfx_x, gfx_y, fftsize, SONOSURFACE, SONOSURFACE2, gfx_mode)
-  local(val)
+  local(val, f, accumulated_step, current_max, stepsize, N)
 (
   x = xp;
   y = yp;
@@ -960,28 +1028,35 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
     ( logarithmic == 0 ) ? 
     (
       // Actual FFT density is better than what we can display
-      N = .5*fmax/sonoSize;
-      norm = sonoScale/N;
-      ( N > 1 ) ?
+      gfx_x = sonoSizeX-1;
+      N = 0.5 * fmax / sonoSize;
+      stepsize = 1.0 / N;
+      norm = sonoScale / stepsize;
+      ( stepsize < 1 ) ?
       (
-        gfx_x = sonoSizeX-1;
-        loop(sonoSize,
-          cv = 0;
-          loop(N,
-            cv = cv + norm * sonogramBuffer[];
-            sonogramBuffer += 1;
+        current_max = 0;
+        accumulated_step = 0;
+        while(
+          current_max = max(current_max, sonogramBuffer[]);
+          sonogramBuffer += 1;
+          
+          accumulated_step += stepsize;
+          (accumulated_step > 1) ? (
+            sonoColorLoc = sonoColorMap + 3*ceil( (  invert + ( 1 - 2*invert ) * (1-exp(-norm * current_max))  )*255);   
+            gfx_setpixel(sonoColorLoc[],sonoColorLoc[1],sonoColorLoc[2]);
+            current_max = 0;
+            accumulated_step -= 1;
+            gfx_y -= 1;
           );
-        
-          sonoColorLoc = sonoColorMap + 3*ceil(  (  invert + ( 1 - 2*invert ) * (1-exp(-cv))  )*255);   
-          gfx_setpixel(sonoColorLoc[],sonoColorLoc[1],sonoColorLoc[2]);
-          gfx_y -= 1;
+          
+          gfx_y > 0;
         );
-      ) : ( 
+      ) : (
         // Actual FFT density is crappier    
         N = 1/N;
         i = sonoSize;
         loop(sonoSize/N,
-          sonoColorLoc = sonoColorMap + 3*ceil(  (  invert + ( 1 - 2*invert ) * (1-exp(-sonogramBuffer[]*sonoScale))  )*255);   
+          sonoColorLoc = sonoColorMap + 3*ceil(  (  invert + ( 1 - 2*invert ) * (1-exp(-sonogramBuffer[]*sonoScale))  )*255);
           gfx_r = sonoColorLoc[];
           gfx_g = sonoColorLoc[1];
           gfx_b = sonoColorLoc[2];
@@ -995,7 +1070,7 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
       )
     ) : (
       tl = 0; val = 0;
-      loop(.5*fmax,
+      loop(0.5 * fmax,
         tx = log(1.0+i*xscale)*wsc;
         val = max(val, sonogramBuffer[]);
         
@@ -1014,6 +1089,30 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
         i += 1;
         sonogramBuffer += 1;
       );
+      
+      // TODO
+      
+/*      tx = log(1.0+((f/srate-spectrum_xoffset)*2.0)*400) * wsc;
+      while(
+        gfx_r=gfx_g=gfx_b=intensity; gfx_a=0.8 * slider39 * slider40;
+        dotext = drawtext && (tx > gfx_x && f!=40 && f!=4000 && f != 15000 &&
+           (f<400 || f >= 1000 || f == 500) && (f<6000 || f>=10000) || (tx-ltxt)>.1*gfx_w);
+        tx > lx ? ( lx=tx+4; gfx_line(tx,spectrum_yoffset,tx,gfx_h - spectrum_yoffsetbottom - (dotext ? 0 : gfx_texth+2),0); );
+        // NOTE: Note that the line above didn't have a rescale Y
+        gfx_r=gfx_g=gfx_b=textintensity; gfx_a=0.9;
+        dotext ? (
+          ltxt = tx;
+          gfx_x = tx + 3;
+          gfx_y = gfx_h-gfx_texth-spectrum_yoffsetbottom;
+          gfx_line( gfx_x-3, gfx_y, gfx_x-3, gfx_y+gfx_texth );
+          f>=1000 ? gfx_printf("%dkHz",f*.001) : gfx_printf("%dHz",f);
+        );
+        f += (f<100?10:f<1000?100:f<10000?1000:5000);
+        tx = log(1.0+((f/srate-spectrum_xoffset)*2.0)*400) * wsc;
+        tx < spectrum_xmax
+      );
+  */    
+      
     );
   );
   
@@ -1040,6 +1139,7 @@ function drawSono(sonogramBuffer, sonoColorMap, invert, sonoScale, xp, yp, wp, h
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h);  
   gfx_blit(blurred, 1, 0, 0, 0, sonoSizeX, sonoSize, x, y, w, h); */   
   gfx_mode = 0;
+  this.sonoGrid(logarithmic, x, y, w, h, fmaxFactor);
 );
 
 function to_x(f)
@@ -1828,6 +1928,12 @@ instance()
 );
 
 (mouse_cap & 1) ? (
+  (cap_mode == 0) ? (
+    drawHz = 1;
+  ) : (
+    drawHz = 0;
+  );
+
    !(last_mouse_cap & 1) ? (
       // Reset to defaults
        (cap_mode == 1||cap_mode == 4||cap_mode == 5||cap_mode == 6||cap_mode == 8||cap_mode == 9||cap_mode == 10||cap_mode ==30||cap_mode ==31
@@ -1978,8 +2084,7 @@ instance()
 
                  (      // Note that the sonogram condition works for capmode8 and 9 (sonogram / scope) since they are in the same position 
                     (slider42 == 0) ? sonogram_button.hit_button(mouse_x,mouse_y,-1) ? ( slider29=slider29+1; slider29>3?slider29=0; slider_automate(slider29); old_w = 0 ):
-                    (slider42 == 0) ? sonoLog.hit_button(mouse_x,mouse_y,-1) ? ( slider33=!slider33; slider_automate(slider33); updateSliders = 1; old_w = 0) :
-                    drawHz = 1;
+                    (slider42 == 0) ? sonoLog.hit_button(mouse_x,mouse_y,-1) ? ( slider33=!slider33; slider_automate(slider33); updateSliders = 1; old_w = 0)
                 )                
           );
           
@@ -2060,7 +2165,7 @@ instance()
     ) :
     cap_mode == 8 && cap_last_y != mouse_y ? (
       // Sonogram
-      slider30 = drag_slider(slider30, 0, 15000, 100);
+      slider30 = drag_slider(slider30, 0, 35000, 100);
       old_w=0;
       slider_automate(slider30);
     ) :


### PR DESCRIPTION
Made a few additions to the sonogram display.

- There is now a right click context menu that allows you to choose various display options
- There is an optional frequency grid.
- Right click context menu can be used to switch between log and non-log display.
- Scrollwheel still enables zooming into the low frequencies.
- Left click still drags the scale, for which there is now visual feedback.
- The color mapping was also overhauled and is now done logarithmically, to be more in line with the rest of the analyzer.
