### PR TITLE
spectral analyzer: add option to hide spectrum in favor of sono

### DIFF
--- a/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
+++ b/SpectrumAnalyzer/SaikeMultiSpectralAnalyzer.jsfx
@@ -1,8 +1,8 @@
 desc:Saike Spectral Analyzer (beta)
 tags: analysis FFT meter spectrum
-version: 5.0.26
+version: 5.0.27
 author: Joep Vanlier, Trond-Viggo Melssen, Cockos, Feed The Cat
-changelog: Added optional approximately perceptually linear but colorful turbo and redblue maps.
+changelog: Add option to hide spectral view. Nest colormap menu.
 provides: colormaps.jsfx-inc
 Copyright (C) 2007 Cockos Incorporated
 Copyright (C) 2018 Joep Vanlier, Trond-Viggo Melssen
@@ -323,6 +323,7 @@ file_var(0, fftSizeB);
 file_var(0, xscaleB);
 file_var(0, showNotes);
 file_var(0, legacy_style);
+file_var(0, hide_spectrum);
 
 @slider
 slider2 != lfloor ? old_w=0;
@@ -1923,7 +1924,7 @@ instance()
 
     ( mouse_y < (gfx_h-sono_yoffset_bottom-sono_size) ) && ( mouse_x < ( gfx_w - spectrum_xpad ) ) ? 
     (
-      ( zoomMode == 0 ) ? (
+      ( zoomMode == 0 && (hide_spectrum == 0) ) ? (
         // Not zooming
         old_mouse_x = mouse_x;
         old_mouse_y = mouse_y;
@@ -1943,7 +1944,7 @@ instance()
       ((mouse_y > gfx_h-sono_yoffset_bottom-sono_size) && (mouse_y < gfx_h - sono_yoffset_bottom)) ? (
         gfx_x = mouse_x;
         gfx_y = mouse_y;
-        sprintf(22, "%sMagma|%sMagma (inverted)|%sViridis|%sViridis (inverted)|%sInferno|%sInferno (inverted)|%sPlasma|%sPlasma (inverted)|%sTurbo|%sTurbo (inverted)|%sRed Blue|%sRed Blue (inverted)|%sLogarithmic|%sShow Grid|%sLegacy style",
+        sprintf(22, ">Colormaps|%sMagma|%sMagma (inverted)|%sViridis|%sViridis (inverted)|%sInferno|%sInferno (inverted)|%sPlasma|%sPlasma (inverted)|%sTurbo|%sTurbo (inverted)|%sRed Blue|<%sRed Blue (inverted)|%sLogarithmic|%sShow Grid|%sLegacy style|%sShow only sonogram",
         slider32 == 0 ? "!" : "",
         slider32 == 1 ? "!" : "",
         slider32 == 2 ? "!" : "",
@@ -1958,7 +1959,8 @@ instance()
         slider32 == 11 ? "!" : "",
         slider33 ? "!" : "",
         (sonoGridAlpha == 0) ? "": "!",
-        legacy_style ? "!" : ""
+        legacy_style ? "!" : "",
+        hide_spectrum ? "!": ""
         );
         ret = gfx_showmenu(22);
         (ret > 0 && ret < 13) ? (
@@ -1969,6 +1971,8 @@ instance()
           sonoGridAlpha = (sonoGridAlpha == 0) ? 0.4 : 0;
         ) : (ret == 15) ? (
           legacy_style = 1 - legacy_style;
+        ) : (ret == 16) ? (
+          hide_spectrum = 1 - hide_spectrum;
         );
       );
     );
@@ -2563,7 +2567,15 @@ function DrawButtons()
 
 function updateSpectralBounds()
 (
-  slider29 == 3 ? sono_size = 0 : sono_size = sono_frac*gfx_h;
+  slider29 == 3 ? (
+    sono_size = 0
+  ) : (
+    hide_spectrum ? (
+      sono_size = gfx_h - (25 + sono_yoffset_bottom) * (1.0 - micro_view);
+    ) : (
+      sono_size = sono_frac * gfx_h
+    );
+  );
 
   // SET THE OFFSETS HERE
   spectrum_yoffset = 25 * (1 - hideUI) * (1 - micro_view) * (1 + 0.7 * (gfx_ext_retina == 2));
@@ -2823,15 +2835,17 @@ mouse_cap > 0 ? (
     integrate_sc=1;
   );
   
-  displayMode == 0 ? drawSpectra(recpositions, fftworkspaces, integrate_bufs, shifts, histsizes)
-  : displayMode == 1 ? drawDifferenceSpectra(recpositions, fftworkspaces, integrate_bufs, shifts, histsizes);
+  !hide_spectrum ? (
+    displayMode == 0 ? drawSpectra(recpositions, fftworkspaces, integrate_bufs, shifts, histsizes)
+    : displayMode == 1 ? drawDifferenceSpectra(recpositions, fftworkspaces, integrate_bufs, shifts, histsizes);
   
-  ( zoomMode == 1 ) ? (
-    gfx_r = gfx_g = gfx_b = gfx_a = 1.0;
-    gfx_line( old_mouse_x, old_mouse_y, mouse_x, old_mouse_y );
-    gfx_line( old_mouse_x, old_mouse_y, old_mouse_x, mouse_y );
-    gfx_line( old_mouse_x, mouse_y, mouse_x, mouse_y );
-    gfx_line( mouse_x, old_mouse_y, mouse_x, mouse_y );
+    ( zoomMode == 1 ) ? (
+      gfx_r = gfx_g = gfx_b = gfx_a = 1.0;
+      gfx_line( old_mouse_x, old_mouse_y, mouse_x, old_mouse_y );
+      gfx_line( old_mouse_x, old_mouse_y, old_mouse_x, mouse_y );
+      gfx_line( old_mouse_x, mouse_y, mouse_x, mouse_y );
+      gfx_line( mouse_x, old_mouse_y, mouse_x, mouse_y );
+    );
   );
   
   // Note: slider34 can still be used to detect clicks on the sono
@@ -2906,7 +2920,7 @@ mouse_cap > 0 ? (
     invert = slider32 - (floor(slider32/2))*2;
     ( selected > -1 ) ? (
       // Make sure that the sonogram is still updated if it's not currently being rendered.       
-      (activeChannels[selected] == 0) ? (
+      (activeChannels[selected] == 0 || hide_spectrum) ? (
         processFFT(recpositions[selected], fftworkspaces[selected], integrate_bufs[selected], shifts[selected], histsizes[selected], ccolor[0], ccolor[1], ccolor[2], 1, 0);
       );
       sonogram.drawSono(fftworkspaces[selected], cmapidx * 1000, invert, slider30, gfx_x, gfx_y, sigw*gfx_w, sigh*gfx_h, slider33, slider35);
@@ -2918,7 +2932,7 @@ mouse_cap > 0 ? (
 //      gfx_printf( "Ch: %d, Sc: %d", selected + 1, slider30 );
       !micro_view ? gfx_printf(" %d", selected + 1);
     ) : (
-      ( (showSum == 0) || (displayMode == 1) ) ? (
+      ( (showSum == 0) || (displayMode == 1) || hide_spectrum ) ? (
         // Make sure that the sonogram is still updated if it's not currently being rendered.
         processFFT(sumposr, fftwr, ibufr, sumshr, sumhsr, halfshade, halfshade, halfshade, 0, 0);  
         processFFT(sumposl, fftwl, ibufl, sumshl, sumhsl, shade, shade, shade, 0, 0);
@@ -2946,7 +2960,7 @@ mouse_cap > 0 ? (
     gfx_mode = 0;
   );
   
-  drawGrid();
+  !hide_spectrum ? drawGrid();
   (!hideUI && !micro_view) ? DrawButtons();
   updateSpectralBounds();
   gfx_r=gfx_g=gfx_b=gfx_a=1.0;
@@ -2958,7 +2972,7 @@ mouse_cap > 0 ? (
     gfx_blit(UI_SCREEN, 1, 0);
   );
   
-  ( drawHz == 1 ) ? (
+  ( drawHz == 1 && !hide_spectrum ) ? (
     gfx_r = gfx_g = gfx_b = 1 - bgColor;
     gfx_a = 1.0;
     gfx_x = mouse_x + 10;


### PR DESCRIPTION
Adds to option to hide the spectrum entirely when only a sonogram is desired (saves on CPU too).