### PR TITLE
DuskVerb Version 0.6

### DIFF
--- a/DuskVerb/DuskVerb_Dependencies/saike_dusk_grainlib.jsfx-inc
+++ b/DuskVerb/DuskVerb_Dependencies/saike_dusk_grainlib.jsfx-inc
@@ -161,6 +161,22 @@ function granulator_init()
     this.grain12.idx = 
     this.grain13.idx = 
     this.grain14.idx = 100000000000000000000000000000000;
+    
+    this.grain0.lOut = this.grain0.rOut = 
+    this.grain1.lOut = this.grain1.rOut = 
+    this.grain2.lOut = this.grain2.rOut = 
+    this.grain3.lOut = this.grain3.rOut = 
+    this.grain4.lOut = this.grain4.rOut = 
+    this.grain5.lOut = this.grain5.rOut = 
+    this.grain6.lOut = this.grain6.rOut = 
+    this.grain7.lOut = this.grain7.rOut = 
+    this.grain8.lOut = this.grain8.rOut = 
+    this.grain9.lOut = this.grain9.rOut = 
+    this.grain10.lOut = this.grain10.rOut = 
+    this.grain11.lOut = this.grain11.rOut = 
+    this.grain12.lOut = this.grain12.rOut = 
+    this.grain13.lOut = this.grain13.rOut = 
+    this.grain14.lOut = this.grain14.rOut = 0;
   );
 
 function granulator_set_buffer_limits(start, size)
@@ -204,7 +220,7 @@ global()
 
 function granulator_update(new_grain, grain_samples, speed, pan_spread, reverse_probability, playing, offset)
 local(pan, reverse, cpan, cpan_l, cpan_r, ptr, N)
-global(srate, last_ptr, granulator_error)
+global(srate, last_ptr, granulator_error, active_grains)
 instance(next_gain, l, r, gl, gr, write_ptr, buffer_start, buffer_end, buffer_length)
 (
   // grain_samples is how many samples we want the grain to play
@@ -244,21 +260,22 @@ instance(next_gain, l, r, gl, gr, write_ptr, buffer_start, buffer_end, buffer_le
     : this.grain14.initGrain(ptr, N, N, buffer_start, buffer_end, speed, cpan_l, cpan_r) ? ( 0 )
   );
   
-  (this.grain0.idx <= this.grain0.N3) ? this.grain0.grainRead();
-  (this.grain1.idx <= this.grain1.N3) ? this.grain1.grainRead();
-  (this.grain2.idx <= this.grain2.N3) ? this.grain2.grainRead();
-  (this.grain3.idx <= this.grain3.N3) ? this.grain3.grainRead();
-  (this.grain4.idx <= this.grain4.N3) ? this.grain4.grainRead();
-  (this.grain5.idx <= this.grain5.N3) ? this.grain5.grainRead();
-  (this.grain6.idx <= this.grain6.N3) ? this.grain6.grainRead();
-  (this.grain7.idx <= this.grain7.N3) ? this.grain7.grainRead();
-  (this.grain8.idx <= this.grain8.N3) ? this.grain8.grainRead();
-  (this.grain9.idx <= this.grain9.N3) ? this.grain9.grainRead();
-  (this.grain10.idx <= this.grain10.N3) ? this.grain10.grainRead();
-  (this.grain11.idx <= this.grain11.N3) ? this.grain11.grainRead();
-  (this.grain12.idx <= this.grain12.N3) ? this.grain12.grainRead();
-  (this.grain13.idx <= this.grain13.N3) ? this.grain13.grainRead();
-  (this.grain14.idx <= this.grain14.N3) ? this.grain14.grainRead();
+  active_grains = 0;
+  (this.grain0.idx <= this.grain0.N3) ? ( this.grain0.grainRead(); active_grains += 1; );
+  (this.grain1.idx <= this.grain1.N3) ? ( this.grain1.grainRead(); active_grains += 1; );
+  (this.grain2.idx <= this.grain2.N3) ? ( this.grain2.grainRead(); active_grains += 1; );
+  (this.grain3.idx <= this.grain3.N3) ? ( this.grain3.grainRead(); active_grains += 1; );
+  (this.grain4.idx <= this.grain4.N3) ? ( this.grain4.grainRead(); active_grains += 1; );
+  (this.grain5.idx <= this.grain5.N3) ? ( this.grain5.grainRead(); active_grains += 1; );
+  (this.grain6.idx <= this.grain6.N3) ? ( this.grain6.grainRead(); active_grains += 1; );
+  (this.grain7.idx <= this.grain7.N3) ? ( this.grain7.grainRead(); active_grains += 1; );
+  (this.grain8.idx <= this.grain8.N3) ? ( this.grain8.grainRead(); active_grains += 1; );
+  (this.grain9.idx <= this.grain9.N3) ? ( this.grain9.grainRead(); active_grains += 1; );
+  (this.grain10.idx <= this.grain10.N3) ? ( this.grain10.grainRead(); active_grains += 1; );
+  (this.grain11.idx <= this.grain11.N3) ? ( this.grain11.grainRead(); active_grains += 1; );
+  (this.grain12.idx <= this.grain12.N3) ? ( this.grain12.grainRead(); active_grains += 1; );
+  (this.grain13.idx <= this.grain13.N3) ? ( this.grain13.grainRead(); active_grains += 1; );
+  (this.grain14.idx <= this.grain14.N3) ? ( this.grain14.grainRead(); active_grains += 1; );
 
   l = this.grain0.lOut + this.grain1.lOut + this.grain2.lOut + this.grain3.lOut + this.grain4.lOut + this.grain5.lOut + this.grain6.lOut + this.grain7.lOut + this.grain8.lOut + this.grain9.lOut + this.grain10.lOut  + this.grain11.lOut;  + this.grain12.lOut;  + this.grain13.lOut;  + this.grain14.lOut;
   r = this.grain0.rOut + this.grain1.rOut + this.grain2.rOut + this.grain3.rOut + this.grain4.rOut + this.grain5.rOut + this.grain6.rOut + this.grain7.rOut + this.grain8.rOut + this.grain9.rOut + this.grain10.rOut  + this.grain11.rOut   + this.grain12.rOut   + this.grain13.rOut   + this.grain14.rOut;

--- a/DuskVerb/saike_duskverb.jsfx
+++ b/DuskVerb/saike_duskverb.jsfx
@@ -1,8 +1,8 @@
 desc:Dusk Verb (saike) (Public alpha)
 tags: effect, reverb, atmosphere, granular, long
-version: 0.05
+version: 0.06
 author: Joep Vanlier
-changelog: Bugfix in slider naming (thanks fotisandstuff!).
+changelog: Add new grain mode
 license: MIT
 provides:
   DuskVerb_Dependencies/* 
@@ -13,7 +13,7 @@ about:
   ### Features:
   - 3 Reverberation algorithms.
   - Granular resampler.
-  - Frequency shifter / pitch shifter.
+  - Frequency shifter / pitch shifter. 
   - Several audio shimmer modes.
   - X/Y controls for automation.
   - Classic adventure game look.
@@ -30,7 +30,7 @@ slider9:verb_mix=0.4<0, 1, 0.01>-Verb Mix (Verb Y)
 slider10:placeholder=1<0, 1, 1>-placeholder
 slider11:shimmer_mode=0<0,1,1>-Shimmer Mode
 slider20:haunt_algorithm=0<0,1,1>-Haunt Algorithm
-slider30:grain_algorithm=0<0,3,1>-Grain Algorithm
+slider30:grain_algorithm=0<0,4,1>-Grain Algorithm
 slider31:grain_par1=0.5<0,1,0.0001>-Grain Length (Grain X)
 slider32:grain_par2=0.5<0,1,0.0001>-Grain Frequency
 slider40:brightness=0.5<0,1,0.00001>-Brightness (Verb X)
@@ -367,6 +367,20 @@ granulator.granulator_in(spl0, spl1);
   pan_spread = 1;
   reverse_probability = 1;
   grain_offset = 0;
+) : (grain_algorithm == 5) ? (
+  start_factor = 2;
+  beat_frac = start_factor * beat_pos - floor(start_factor * beat_pos);
+  fire_grain = beat_frac < last_beat_frac;
+  diff = beat_frac - last_beat_frac;
+  last_beat_frac = beat_frac;
+  beat_pos += dbeat;
+  
+  grain_count_factor =  pow(2, floor(4 * grain_par1 - 2));
+  grain_samples = samples_per_beat * pow(2, floor(4 * grain_par1 - 2));
+  speed = 0.5;//1 + floor(rand() * 2);
+  pan_spread = 1;
+  reverse_probability = 0.0125;
+  grain_offset = 0;
 );
 
 playing = 1;
@@ -375,6 +389,9 @@ current_grain_mix ? granulator.granulator_update(fire_grain, grain_samples, spee
 (grain_algorithm == 4) ? (
   granulator.l = grain_blip_left.blips(granulator.l, 0.95);
   granulator.r = grain_blip_right.blips(granulator.r, 0.95);
+) : (grain_algorithm == 5) ? (
+  granulator.l += 0.125 * grain_blip_left.blips(granulator.l, 0.95);
+  granulator.r += 0.125 * grain_blip_right.blips(granulator.r, 0.95);
 );
 
 current_grain_mix > 1 ? (
@@ -537,7 +554,7 @@ gfx_r = gfx_g = gfx_b = gfx_a = 1 + light1;
 gfx_blit(7, 1, 0);
 
 gfx_a = 0.1;
-pad_width = 53;
+pad_width = 57;
 pad_height = 24;
 pad_spacing = 31;
 
@@ -579,6 +596,7 @@ choiceg2.choice_toggle(gfx_x, cy, 4, 1, 30, "Burst");
 choiceg3.choice_toggle(gfx_x, cy, 4, 2, 30, "Rapid");
 choiceg4.choice_toggle(gfx_x, cy, 4, 3, 30, "Beat synced\ndoubler");
 choiceg5.choice_toggle(gfx_x, cy, 4, 4, 30, "Stochastic\nBandpass");
+choiceg6.choice_toggle(gfx_x, cy, 4, 5, 30, "Slow");
 grain_pad.xy_pad(3, 3, cy + 5, pad_width, pad_height);
 
 cy += pad_spacing;

--- a/DuskVerb/saike_duskverb.jsfx
+++ b/DuskVerb/saike_duskverb.jsfx
@@ -1,8 +1,8 @@
 desc:Dusk Verb (saike) (Public alpha)
 tags: effect, reverb, atmosphere, granular, long
-version: 0.06
+version: 0.07
 author: Joep Vanlier
-changelog: Add new grain mode
+changelog: Add new haunt modes
 license: MIT
 provides:
   DuskVerb_Dependencies/* 
@@ -29,7 +29,7 @@ slider8:grain_mix=0.2<0, 2, 0.01>-Grain Mix (Grain Y)
 slider9:verb_mix=0.4<0, 1, 0.01>-Verb Mix (Verb Y)
 slider10:placeholder=1<0, 1, 1>-placeholder
 slider11:shimmer_mode=0<0,1,1>-Shimmer Mode
-slider20:haunt_algorithm=0<0,1,1>-Haunt Algorithm
+slider20:haunt_algorithm=0<0,3,1>-Haunt Algorithm
 slider30:grain_algorithm=0<0,4,1>-Grain Algorithm
 slider31:grain_par1=0.5<0,1,0.0001>-Grain Length (Grain X)
 slider32:grain_par2=0.5<0,1,0.0001>-Grain Frequency
@@ -237,7 +237,8 @@ hp.init_linearSVF_absolute(hp_freq, 0);
 side.init_linearSVF_absolute(side_freq, 0);
 brightness_boost.init_linearSVF_shelf_absolute(970, 1.41, hf_boost);
 
-freq_shifter.init_cheapest_freq_shifter(freq_shift);
+achieved = freq_shift * 0.05  - 50;
+freq_shifter.init_cheapest_freq_shifter(haunt_algorithm == 3 ? freq_shift * 0.05  - 50 : freq_shift);
 spinner.block_spinner();
 
 beat_pos = beat_position;
@@ -433,6 +434,11 @@ current_verb_mix ? (
   verb.in.in.in.in.s5 = in_haunt * freq_shifter.outR;
   overall_scaling_factor = verb.in.in.in.scaling_factor * verb.in.in.scaling_factor * verb.in.scaling_factor * verb.scaling_factor;
   
+  (haunt_algorithm == 2) ? (
+     verb.in.in.in.in.s4 += freq_shift_amount * haunt_blip_left.blips(out_left - spl0, 0.94 + 0.0000340 * freq_shift);
+     verb.in.in.in.in.s5 += freq_shift_amount * haunt_blip_right.blips(out_right - spl1, 0.94 + 0.0000340 * freq_shift);
+  );
+  
   sample_verb(current_mode);
   
   out_left = verb.s0 * overall_scaling_factor;
@@ -440,6 +446,14 @@ current_verb_mix ? (
 ) : (
   out_left = 0;
   out_right = 0;
+);
+
+// Barber pole
+(haunt_algorithm == 3) ? (
+  freq_shift_amount ? freq_shifter.eval_cheapest_freq_shifter(out_left, out_right);
+  
+  out_left -= freq_shift_amount * freq_shifter.outR;
+  out_right -= freq_shift_amount * freq_shifter.outL;
 );
 
 // Doppler thingy
@@ -618,6 +632,8 @@ verb_mix == 0 ? gfx_a = 0.1;
 txt_blit("Haunt", 5, cy);
 choiceh1.choice_toggle(gfx_x, cy, 4, 0, 20, "Freq-Shifter");
 choiceh2.choice_toggle(gfx_x, cy, 4, 1, 20, "Spinner");
+choiceh3.choice_toggle(gfx_x, cy, 4, 2, 20, "Ghostly Chill");
+choiceh4.choice_toggle(gfx_x, cy, 4, 3, 20, "Incoherence");
 haunt.xy_pad(2, 3, cy + 5, pad_width, pad_height);
 
 /*

--- a/DuskVerb/saike_duskverb.jsfx
+++ b/DuskVerb/saike_duskverb.jsfx
@@ -1,8 +1,8 @@
 desc:Dusk Verb (saike) (Public alpha)
 tags: effect, reverb, atmosphere, granular, long
-version: 0.08
+version: 0.09
 author: Joep Vanlier
-changelog: Increase Y-range haunt mode
+changelog: Fix bug related to stopping transport. The granular module was synced to the beat. When transport was stopped at exactly a beat, it previously kept firing grains. Since there is a limited number of grains in the pool, this in turn leads to them all being occupied. As a result, when playback is resumed, few grains are available for playback. Instead, now, when playback is stopped, the plugin switched to its own internal clock for maintaining synchronization. Thanks a lot for the bug report Someone65! Very helpful!
 license: MIT
 provides:
   DuskVerb_Dependencies/* 
@@ -241,7 +241,11 @@ achieved = freq_shift * 0.05  - 50;
 freq_shifter.init_cheapest_freq_shifter(haunt_algorithm == 3 ? freq_shift * 0.05  - 50 : freq_shift);
 spinner.block_spinner();
 
-beat_pos = beat_position;
+((play_state == 1) || (play_state == 5)) ? ( 
+  // Sync to transport if playing
+  beat_pos = beat_position;
+);
+
 dbeat = (tempo / 60) / srate;  // Beats per sample
 samples_per_beat = 1.0 / dbeat;
 

--- a/DuskVerb/saike_duskverb.jsfx
+++ b/DuskVerb/saike_duskverb.jsfx
@@ -1,8 +1,8 @@
 desc:Dusk Verb (saike) (Public alpha)
 tags: effect, reverb, atmosphere, granular, long
-version: 0.07
+version: 0.08
 author: Joep Vanlier
-changelog: Add new haunt modes
+changelog: Increase Y-range haunt mode
 license: MIT
 provides:
   DuskVerb_Dependencies/* 
@@ -23,7 +23,7 @@ slider2:seed=9860959.345567<0,12311323,1>-Random Seed
 slider3:mode=0<0,2,1>-Reverb Mode
 slider4:shimmer=0.4<0,1,0.00001>-Upward Shimmer (Shimmer Y)
 slider5:shifter_down=0<0,1,0.00001>-Downward Shimmer (Shimmer X)
-slider6:freq_shift_amount=0<0,1.0,0.00001>-Frequency Amount (Haunt Y)
+slider6:freq_shift_amount=0<0,1.5.0,0.00001>-Frequency Amount (Haunt Y)
 slider7:freq_shift=60<60,880,0.00001>-Frequency Shift (Haunt X)
 slider8:grain_mix=0.2<0, 2, 0.01>-Grain Mix (Grain Y)
 slider9:verb_mix=0.4<0, 1, 0.01>-Verb Mix (Verb Y)
@@ -58,7 +58,7 @@ options:maxmem=220000000
 CURRENT_VERSION = 1;
 version = CURRENT_VERSION;
 
-haunt.init_xy(7, 60, 880, 0, 6, 0, 1.0, 0);
+haunt.init_xy(7, 60, 880, 0, 6, 0, 1.5, 0);
 shimmer_pad.init_xy(5, 0, 1, 0, 4, 0, 1, 0);
 grain_pad.init_xy(31, 0, 1, 0, 8, 0, 2, 0);
 verb_pad.init_xy(40, 0, 1, 0, 9, 0, 1, 0);


### PR DESCRIPTION
- Adds two more haunt modes.
- Adds one grain mode.
- Fixes a bug related to stopping transport. The granular module is synced to the beat. When transport was stopped at exactly a beat, it previously kept firing grains (since we land on the beat transition continuously). Since there is a limited number of grains in the pool, this in turn leads to them all being occupied. As a result, when playback is resumed, few grains are available for playback. Instead, now, when playback is stopped, the plugin switched to its own internal clock for maintaining synchronization. Thanks a lot for the bug report Someone65! Very helpful!
