### PR TITLE
midi_arp: reset midi after all previous notes are released

### DIFF
--- a/saike_midi_arp/midi_arp_dependencies/saike_arp_midi_handling.jsfx-inc
+++ b/saike_midi_arp/midi_arp_dependencies/saike_arp_midi_handling.jsfx-inc
@@ -79,7 +79,7 @@ global(time_mode, reset_playhead)
   while(note_next == curSample) (
     note_ptr += 1;
     (note_ptr[] > 0) ? ( // note-on
-      (time_mode == 1) ? (reset_playhead = 1);
+      (time_mode == 1 && notes_on == 0) ? (reset_playhead = 1);
       
       notes_on = notes_on + 1;
       velocity = note_ptr[]/127;

--- a/saike_midi_arp/saike_midi_arp.jsfx
+++ b/saike_midi_arp/saike_midi_arp.jsfx
@@ -1,8 +1,8 @@
 desc:Saike MIDI ARP (beta)
 tags: midi arpeggiator
-version: 0.34
+version: 0.35
 author: Joep Vanlier
-changelog: Bump version number.
+changelog: When set to MIDI mode, reset the pattern only after all previous notes are relased.
 license: MIT
 provides:
   midi_arp_dependencies/*


### PR DESCRIPTION
Currently MIDI mode resets the playhead as soon as any new note is pressed, I thought it would be useful to play a chord and be able to for example change one note to create some variation without fully resetting the pattern, to allow this, this PR adds an additional condition to make the playhead reset only after all of the previous notes have been released (similar to BlueARP when configured to reset on 'key').

