### PR TITLE
midi_arp: fix polyphony button min/max values

### DIFF
--- a/saike_midi_arp/saike_midi_arp.jsfx
+++ b/saike_midi_arp/saike_midi_arp.jsfx
@@ -1072,7 +1072,7 @@ pattern_toggle.value == 0 ? (
 ( pattern_toggle.value == 10 ) ? ( current_speed = min(current_speed + 1, 16); slider_automate(1); ) :
 ( pattern_toggle.value == 9 ) ? ( current_speed = max(min(current_speed + pattern_toggle.change, 16), -6); slider_automate(1);) :
 ( pattern_toggle.value == 8 ) ? ( current_speed = max(current_speed - 1, -6); slider_automate(1); ) :
-( pattern_toggle.value == 11 ) ? ( polyphony = max(min(polyphony + pattern_toggle.change, 6), 2); ) : 
+( pattern_toggle.value == 11 ) ? ( polyphony = max(min(polyphony + pattern_toggle.change, 12), 1); ) : 
 ( pattern_toggle.value == 12 ) ? ( extra_octaves = max(min(extra_octaves + pattern_toggle.change, 2), 0); ) :
 ( pattern_toggle.value == 13 ) ? ( slider_automate(swing = max(min(swing + pattern_toggle.change, 50), -50 );); );
 

--- a/saike_midi_arp/saike_midi_arp.jsfx
+++ b/saike_midi_arp/saike_midi_arp.jsfx
@@ -1,8 +1,8 @@
 desc:Saike MIDI ARP (beta)
 tags: midi arpeggiator
-version: 0.35
+version: 0.36
 author: Joep Vanlier
-changelog: When set to MIDI mode, reset the pattern only after all previous notes are relased.
+changelog: Fix polyphony button to allow creation of patterns with up to 12 notes.
 license: MIT
 provides:
   midi_arp_dependencies/*


### PR DESCRIPTION
The polyphony button is clamped to min=2 and max=6, however polyphony can actually be automated and be set to values between 1 and 12 (also MAX_POLYPHONY constant seems to be set to 12), this PR fixes the button ranges so that we can create patterns with more than 6 notes without working around it via polyphony automation.